### PR TITLE
fix: missing dep @trivago/prettier-plugin-sort-imports

### DIFF
--- a/cli/plasmo/src/features/extension-devtools/package-file.ts
+++ b/cli/plasmo/src/features/extension-devtools/package-file.ts
@@ -28,7 +28,7 @@ export const generatePackage = ({
       "react-dom": "18.1.0"
     } as Record<string, string>,
     devDependencies: {
-      "@trivago/prettier-plugin-sort-imports": "^3.2.0",
+      "@trivago/prettier-plugin-sort-imports": "3.2.0",
       "@types/chrome": "0.0.190",
       "@types/node": "17.0.42",
       "@types/react": "18.0.12",

--- a/cli/plasmo/src/features/extension-devtools/package-file.ts
+++ b/cli/plasmo/src/features/extension-devtools/package-file.ts
@@ -28,6 +28,7 @@ export const generatePackage = ({
       "react-dom": "18.1.0"
     } as Record<string, string>,
     devDependencies: {
+      "@trivago/prettier-plugin-sort-imports": "^3.2.0",
       "@types/chrome": "0.0.190",
       "@types/node": "17.0.42",
       "@types/react": "18.0.12",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug
1. run `pnpm dlx plasmo init example-dir`
2. `.prettierrc.cjs` has require `@trivago/prettier-plugin-sort-imports` , but not in `package.json`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Documentation added
- [ ] Example added

## Documentation / Examples

- [ ] Update https://github.com/PlasmoHQ/docs
