### PR TITLE
fix(cli): package name is empty after use "." as workdir

### DIFF
--- a/cli/plasmo/src/commands/init.ts
+++ b/cli/plasmo/src/commands/init.ts
@@ -48,8 +48,8 @@ async function init() {
     ).rawName
 
   const packageName = paramCase(rawName)
-
-  const projectDirectory = resolve(cwd(), packageName)
+  const currentDirectory = cwd()
+  const projectDirectory = resolve(currentDirectory, packageName)
   vLog("Absolute path:", projectDirectory)
 
   if (!existsSync(projectDirectory)) {
@@ -75,9 +75,11 @@ async function init() {
   )
 
   const packageFilePath = resolve(projectDirectory, "package.json")
+  const packageNameFromDirectory = currentDirectory.split('/').pop()
+  vLog("Package name:", packageName || packageNameFromDirectory)
 
   const packageData = generatePackage({
-    name: packageName,
+    name: packageName || packageNameFromDirectory,
     packageManager
   })
 

--- a/cli/plasmo/src/commands/init.ts
+++ b/cli/plasmo/src/commands/init.ts
@@ -75,7 +75,7 @@ async function init() {
   )
 
   const packageFilePath = resolve(projectDirectory, "package.json")
-  const packageNameFromDirectory = currentDirectory.split('/').pop()
+  const packageNameFromDirectory = paramCase(currentDirectory.split('/').pop())
   vLog("Package name:", packageName || packageNameFromDirectory)
 
   const packageData = generatePackage({


### PR DESCRIPTION
## Bug
1. Run `pnpm dlx plasmo init .`
2. `name` in package.json is empty

## Solution
Take the name of the current working directory