### PR TITLE
fix: load `createContentScriptMount` for `.ts` files too (not only `.tsx`)

### DIFF
--- a/cli/plasmo/src/features/extension-devtools/plasmo-extension-manifest.ts
+++ b/cli/plasmo/src/features/extension-devtools/plasmo-extension-manifest.ts
@@ -170,7 +170,8 @@ export class PlasmoExtensionManifest {
         path
       )
 
-      if (extname(manifestScriptPath) === ".tsx") {
+      const needsMount = [".ts", ".tsx"].includes(extname(manifestScriptPath))
+      if (needsMount) {
         // copy the contents and change the manifest path
         const modulePath = join("plasmo", manifestScriptPath).replace(
           /(^src)[\\/]/,


### PR DESCRIPTION
this limitation was, and still is, pretty meh,
because it's implicit, and hard to find.

---

the default template one gets when running `plasmo init`
has `content.ts` (NOT `.tsx`), but includes react content.

this will cause confusion, esp. for new users.

further, a .ts file can import a component from a .tsx file,
thus this restriction for only .tsx files does not make sense.

---

i don't think this is the proper solution,
but will help in the meantime.
