### PR TITLE
feat(parcel-runtime): HMR Reconnect

### DIFF
--- a/cli/create-plasmo/package.json
+++ b/cli/create-plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-plasmo",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Create Plasmo Framework Browser Extension",
   "main": "dist/index.js",
   "bin": "dist/index.js",

--- a/cli/plasmo/package.json
+++ b/cli/plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plasmo",
-  "version": "0.46.1-alpha.0",
+  "version": "0.46.1",
   "description": "The Plasmo Platform CLI",
   "main": "dist/index.js",
   "types": "dist/type.d.ts",

--- a/packages/parcel-config/package.json
+++ b/packages/parcel-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasmohq/parcel-config",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/parcel-runtime/loaders/hmr-runtime.js
+++ b/packages/parcel-runtime/loaders/hmr-runtime.js
@@ -1,3 +1,5 @@
+const ReconnectingWebSocket = require("reconnecting-websocket");
+
 function getHostname() {
   return (
     HMR_HOST ||
@@ -19,7 +21,9 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== "undefined") {
       !/localhost|127.0.0.1|0.0.0.0/.test(hostname))
       ? "wss"
       : "ws"
-  var ws = new WebSocket(
+  
+  // WebSocket will automatically reconnect if the connection is lost. (i.e. restarting `plasmo dev`)
+  var ws = new ReconnectingWebSocket(
     protocol + "://" + hostname + (port ? ":" + port : "") + "/"
   )
 
@@ -85,7 +89,7 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== "undefined") {
   }
   ws.onclose = function (e) {
     if (process.env.PARCEL_BUILD_ENV !== "test") {
-      console.warn("[parcel] 🚨 Connection to the HMR server was lost")
+      console.warn("[parcel] 🚨 Connection to the HMR server was lost, trying to reconnect...")
     }
   }
 }

--- a/packages/parcel-runtime/loaders/hmr-runtime.js
+++ b/packages/parcel-runtime/loaders/hmr-runtime.js
@@ -1,4 +1,4 @@
-const ReconnectingWebSocket = require("reconnecting-websocket");
+const ReconnectingWebSocket = require("reconnecting-websocket")
 
 function getHostname() {
   return (
@@ -21,7 +21,7 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== "undefined") {
       !/localhost|127.0.0.1|0.0.0.0/.test(hostname))
       ? "wss"
       : "ws"
-  
+
   // WebSocket will automatically reconnect if the connection is lost. (i.e. restarting `plasmo dev`)
   var ws = new ReconnectingWebSocket(
     protocol + "://" + hostname + (port ? ":" + port : "") + "/"
@@ -74,7 +74,7 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== "undefined") {
           : ansiDiagnostic.stack
 
         console.error(
-          "🚨 [parcel]: " +
+          "🟡 [plasmo/parcel-runtime]: " +
             ansiDiagnostic.message +
             "\n" +
             stack +
@@ -89,7 +89,9 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== "undefined") {
   }
   ws.onclose = function (e) {
     if (process.env.PARCEL_BUILD_ENV !== "test") {
-      console.warn("[parcel] 🚨 Connection to the HMR server was lost, trying to reconnect...")
+      console.warn(
+        "🟡 [plasmo/parcel-runtime]: Connection to the HMR server was lost, trying to reconnect..."
+      )
     }
   }
 }

--- a/packages/parcel-runtime/package.json
+++ b/packages/parcel-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasmohq/parcel-runtime",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Plasmo Parcel Runtime",
   "files": [
     "dist",

--- a/packages/parcel-runtime/package.json
+++ b/packages/parcel-runtime/package.json
@@ -28,6 +28,7 @@
     "tsup": "6.1.3"
   },
   "dependencies": {
-    "@parcel/plugin": "2.6.2"
+    "@parcel/plugin": "2.6.2",
+    "reconnecting-websocket": "4.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,7 +133,6 @@ importers:
       typescript: 4.7.4
     dependencies:
       antd: 4.21.5_biqbaboplfbrettd7655fr4n2y
-      plasmo: link:../../cli/plasmo
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
@@ -144,6 +143,7 @@ importers:
       '@types/node': 18.0.3
       '@types/react': 18.0.15
       '@types/react-dom': 18.0.6
+      plasmo: link:../../cli/plasmo
       prettier: 2.7.1
       typescript: 4.7.4
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1105,9 +1105,11 @@ importers:
       '@parcel/core': 2.6.2
       '@parcel/plugin': 2.6.2
       '@plasmo/config': workspace:*
+      reconnecting-websocket: 4.4.0
       tsup: 6.1.3
     dependencies:
       '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
+      reconnecting-websocket: 4.4.0
     devDependencies:
       '@parcel/core': 2.6.2
       '@plasmo/config': link:../config
@@ -10642,6 +10644,10 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
+
+  /reconnecting-websocket/4.4.0:
+    resolution: {integrity: sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng==}
+    dev: false
 
   /redux-persist-webextension-storage/1.0.2:
     resolution: {integrity: sha512-WGiK6sNIMLtvZaWqDOZF7Yzz53LOx5YzE9I2bwjZeACtp6+VvfyP57J5czXtTSe9KVSTTPlLmX96jS4agYfwsQ==}


### PR DESCRIPTION
Closes https://discord.com/channels/946290204443025438/983397810533720075/994962911699161180.

## HMR Reconnect

After restarting `plasmo dev`, I have to manually reload my extension (from `chrome://extensions`) for HMR to work - this is because after the `hmr-runtime` WebSocket connection is lost, it never attempts to reconnect. 

This PR adds [`reconnecting-websocket`](https://github.com/pladaria/reconnecting-websocket).