### PR TITLE
feat: add a warning message if there are no entrypoints

### DIFF
--- a/cli/plasmo/src/features/manifest-factory/create-manifest.ts
+++ b/cli/plasmo/src/features/manifest-factory/create-manifest.ts
@@ -2,7 +2,7 @@ import { ensureDir, existsSync } from "fs-extra"
 import { readdir } from "fs/promises"
 import { resolve } from "path"
 
-import { vLog } from "@plasmo/utils"
+import { vLog, wLog } from "@plasmo/utils"
 
 import type { CommonPath } from "~features/extension-devtools/common-path"
 import { generateIcons } from "~features/extension-devtools/generate-icons"
@@ -39,7 +39,7 @@ export async function createManifest(
   const contentIndex = contentIndexList.find(existsSync)
   const backgroundIndex = backgroundIndexList.find(existsSync)
 
-  const [hasPopup, hasOptions, hasNewtab, hasDevtools] = await Promise.all([
+  const hasEntrypoints = await Promise.all([
     manifestData.scaffolder.initTemplateFiles("popup"),
     manifestData.scaffolder.initTemplateFiles("options"),
     manifestData.scaffolder.initTemplateFiles("newtab"),
@@ -56,6 +56,12 @@ export async function createManifest(
         )
       )
   ])
+  
+  if (!hasEntrypoints.includes(true)) {
+    wLog("Unable to find any entrypoints. You may end up with an empty extension...")
+  }
+  
+  const [hasPopup, hasOptions, hasNewtab, hasDevtools] = hasEntrypoints
 
   manifestData
     .togglePopup(hasPopup)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Details

Context: https://discord.com/channels/946290204443025438/978320682985349130/1015413639827705906

### Code of Conduct

- [x] I agree to follow this project's Code of Conduct
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

### Testing

I only tested newtab.tsx, I'm going to assume the underlying `initTemplateFile` function works as expected

with newtab.tsx:
```
➜  with-newtab git:(8fa7fff) pnpm run build   

> with-newtab@0.0.0 build plasmo/examples/with-newtab
> plasmo build

🟣 Plasmo v0.52.5
🟠 The browser extension development framework.
🔵 INFO   | Prepare to bundle the extension...
🟢 DONE   | Finished in 2380ms!
```

after removing newtab.tsx:
```
➜  with-newtab git:(8fa7fff) pnpm run build

> with-newtab@0.0.0 build plasmo/examples/with-newtab
> plasmo build

🟣 Plasmo v0.52.5
🟠 The browser extension development framework.
🔵 INFO   | Prepare to bundle the extension...
🟠 WARN   | Unable to find any entrypoints. You may end up with an empty extension...
🟢 DONE   | Finished in 669ms!
```