### PR TITLE
doc: update hyperlink for submission

### DIFF
--- a/packages/init/templates/README.md
+++ b/packages/init/templates/README.md
@@ -30,4 +30,4 @@ This should create a production bundle for your extension, ready to be zipped an
 
 ## Submit to the webstores
 
-The easiest way to deploy your Plasmo extension is to use the built-in [bpp](https://bpp.browser.market) GitHub action. Prior to using this action however, make sure to build your extension and upload the first version to the store to establish the basic credentials. Then, simply follow [this setup instruction](https://docs.plasmo.com/workflows#submit-your-extension) and you should be on your way for automated submission!
+The easiest way to deploy your Plasmo extension is to use the built-in [bpp](https://bpp.browser.market) GitHub action. Prior to using this action however, make sure to build your extension and upload the first version to the store to establish the basic credentials. Then, simply follow [this setup instruction](https://docs.plasmo.com/workflows/submit) and you should be on your way for automated submission!


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Details
When I tried initializing my project, I noticed that the current link to the docs webpage, for submitting to the web   store, doesn't seem to work.  Specifically, the anchor doesn't seem to jump to any specific content on https://docs.plasmo.com/workflows.  I figured the following link is the right one.

https://docs.plasmo.com/workflows/submit

### Code of Conduct

- [x] I agree to follow this project's Code of Conduct
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.
