### PR TITLE
feat: add PLASMO_SRC_PATH and --src-path

### DIFF
--- a/cli/create-plasmo/package.json
+++ b/cli/create-plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-plasmo",
-  "version": "0.55.2",
+  "version": "0.55.3",
   "description": "Create Plasmo Framework Browser Extension",
   "main": "dist/index.js",
   "bin": "dist/index.js",

--- a/cli/plasmo/index.d.ts
+++ b/cli/plasmo/index.d.ts
@@ -1,7 +1,0 @@
-declare namespace NodeJS {
-  interface ProcessEnv {
-    APP_VERSION?: string
-    VERBOSE?: "true" | "false"
-    NODE_ENV?: "development" | "production" | "test"
-  }
-}

--- a/cli/plasmo/package.json
+++ b/cli/plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plasmo",
-  "version": "0.55.2",
+  "version": "0.55.3",
   "description": "The Plasmo Platform CLI",
   "main": "dist/index.js",
   "types": "dist/type.d.ts",

--- a/cli/plasmo/package.json
+++ b/cli/plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plasmo",
-  "version": "0.55.0",
+  "version": "0.55.1-alpha.2",
   "description": "The Plasmo Platform CLI",
   "main": "dist/index.js",
   "types": "dist/type.d.ts",

--- a/cli/plasmo/src/features/extension-devtools/common-path.ts
+++ b/cli/plasmo/src/features/extension-devtools/common-path.ts
@@ -2,6 +2,8 @@ import { existsSync } from "fs"
 import { basename, resolve } from "path"
 import { cwd } from "process"
 
+import { getFlag } from "@plasmo/utils"
+
 export const getCommonPath = (
   projectDirectory = cwd(),
   target = "chrome-mv3",
@@ -9,10 +11,14 @@ export const getCommonPath = (
 ) => {
   const packageName = basename(projectDirectory)
 
-  const srcPath = resolve(
-    projectDirectory,
-    process.env.PLASMO_SRC_PATH || "src"
-  )
+  process.env.PLASMO_SRC_PATH =
+    getFlag("--src-path") || process.env.PLASMO_SRC_PATH || "src"
+
+  const srcDirectory = resolve(projectDirectory, process.env.PLASMO_SRC_PATH)
+
+  process.env.PLASMO_SRC_DIR = existsSync(srcDirectory)
+    ? srcDirectory
+    : projectDirectory
 
   const buildDirectory = resolve(projectDirectory, "build")
 
@@ -34,7 +40,7 @@ export const getCommonPath = (
     distDirectory,
     distDirectoryName,
 
-    sourceDirectory: existsSync(srcPath) ? srcPath : projectDirectory,
+    sourceDirectory: process.env.PLASMO_SRC_DIR,
     packageFilePath: resolve(projectDirectory, "package.json"),
     gitIgnorePath: resolve(projectDirectory, ".gitignore"),
     assetsDirectory: resolve(projectDirectory, "assets"),

--- a/cli/plasmo/src/features/extension-devtools/common-path.ts
+++ b/cli/plasmo/src/features/extension-devtools/common-path.ts
@@ -1,30 +1,30 @@
-import { existsSync } from "fs";
-import { basename, resolve } from "path";
-import { cwd } from "process";
+import { existsSync } from "fs"
+import { basename, resolve } from "path"
+import { cwd } from "process"
 
 export const getCommonPath = (
   projectDirectory = cwd(),
   target = "chrome-mv3",
   dotPlasmo = ".plasmo"
 ) => {
-  const packageName = basename(projectDirectory);
+  const packageName = basename(projectDirectory)
 
   const srcPath = resolve(
     projectDirectory,
     process.env.PLASMO_SRC_PATH || "src"
-  );
+  )
 
-  const buildDirectory = resolve(projectDirectory, "build");
+  const buildDirectory = resolve(projectDirectory, "build")
 
   const distDirectoryName = `${target}-${
     process.env.NODE_ENV === "production" ? "prod" : "dev"
-  }`;
+  }`
 
-  const distDirectory = resolve(buildDirectory, distDirectoryName);
+  const distDirectory = resolve(buildDirectory, distDirectoryName)
 
-  const dotPlasmoDirectory = resolve(projectDirectory, dotPlasmo);
+  const dotPlasmoDirectory = resolve(projectDirectory, dotPlasmo)
 
-  const cacheDirectory = resolve(dotPlasmoDirectory, "cache");
+  const cacheDirectory = resolve(dotPlasmoDirectory, "cache")
 
   return {
     packageName,
@@ -49,8 +49,8 @@ export const getCommonPath = (
     entryManifestPath: resolve(
       dotPlasmoDirectory,
       `${target}.plasmo.manifest.json`
-    ),
-  };
-};
+    )
+  }
+}
 
-export type CommonPath = ReturnType<typeof getCommonPath>;
+export type CommonPath = ReturnType<typeof getCommonPath>

--- a/cli/plasmo/src/features/extension-devtools/common-path.ts
+++ b/cli/plasmo/src/features/extension-devtools/common-path.ts
@@ -1,27 +1,30 @@
-import { existsSync } from "fs"
-import { basename, resolve } from "path"
-import { cwd } from "process"
+import { existsSync } from "fs";
+import { basename, resolve } from "path";
+import { cwd } from "process";
 
 export const getCommonPath = (
   projectDirectory = cwd(),
   target = "chrome-mv3",
   dotPlasmo = ".plasmo"
 ) => {
-  const packageName = basename(projectDirectory)
+  const packageName = basename(projectDirectory);
 
-  const srcPath = resolve(projectDirectory, "src")
+  const srcPath = resolve(
+    projectDirectory,
+    process.env.PLASMO_SRC_PATH || "src"
+  );
 
-  const buildDirectory = resolve(projectDirectory, "build")
+  const buildDirectory = resolve(projectDirectory, "build");
 
   const distDirectoryName = `${target}-${
     process.env.NODE_ENV === "production" ? "prod" : "dev"
-  }`
+  }`;
 
-  const distDirectory = resolve(buildDirectory, distDirectoryName)
+  const distDirectory = resolve(buildDirectory, distDirectoryName);
 
-  const dotPlasmoDirectory = resolve(projectDirectory, dotPlasmo)
+  const dotPlasmoDirectory = resolve(projectDirectory, dotPlasmo);
 
-  const cacheDirectory = resolve(dotPlasmoDirectory, "cache")
+  const cacheDirectory = resolve(dotPlasmoDirectory, "cache");
 
   return {
     packageName,
@@ -46,8 +49,8 @@ export const getCommonPath = (
     entryManifestPath: resolve(
       dotPlasmoDirectory,
       `${target}.plasmo.manifest.json`
-    )
-  }
-}
+    ),
+  };
+};
 
-export type CommonPath = ReturnType<typeof getCommonPath>
+export type CommonPath = ReturnType<typeof getCommonPath>;

--- a/packages/parcel-config/package.json
+++ b/packages/parcel-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasmohq/parcel-config",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/parcel-resolver/package.json
+++ b/packages/parcel-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasmohq/parcel-resolver",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Plasmo Parcel Resolver",
   "files": [
     "dist"

--- a/packages/parcel-resolver/src/handle-remote-caching.ts
+++ b/packages/parcel-resolver/src/handle-remote-caching.ts
@@ -38,7 +38,7 @@ export async function handleRemoteCaching({
     )
   )
 
-  const fileType = "js"
+  const fileType = target.searchParams.get("plasmo-ext") || "js"
 
   try {
     const code = (await state.got(target.toString()).text()) as string

--- a/packages/parcel-resolver/src/shared.ts
+++ b/packages/parcel-resolver/src/shared.ts
@@ -31,7 +31,7 @@ export const initializeState = async (opts: ResolverOptions) => {
   }
 
   if (state.hasSrc === null) {
-    state.srcDir = resolve(opts.options.cacheDir, "..", "..", "..", "src")
+    state.srcDir = resolve(opts.options.cacheDir, "..", "..", "..", process.env.PLASMO_SRC_PATH || "src")
     state.hasSrc = existsSync(state.srcDir)
 
     state.srcDir = state.hasSrc ? state.srcDir : resolve(state.srcDir, "..")

--- a/packages/parcel-resolver/src/shared.ts
+++ b/packages/parcel-resolver/src/shared.ts
@@ -31,7 +31,11 @@ export const initializeState = async (opts: ResolverOptions) => {
   }
 
   if (state.hasSrc === null) {
-    state.srcDir = resolve(opts.options.cacheDir, "..", "..", "..", process.env.PLASMO_SRC_PATH || "src")
+    state.srcDir = resolve(
+      opts.options.cacheDir,
+      "../../..",
+      process.env.PLASMO_SRC_PATH || "src"
+    )
     state.hasSrc = existsSync(state.srcDir)
 
     state.srcDir = state.hasSrc ? state.srcDir : resolve(state.srcDir, "..")

--- a/packages/parcel-resolver/src/shared.ts
+++ b/packages/parcel-resolver/src/shared.ts
@@ -1,7 +1,5 @@
 import type { Resolver } from "@parcel/plugin"
-import { existsSync } from "fs"
 import type { Got } from "got"
-import { resolve } from "path"
 
 export const relevantExtensionList = [
   ".ts",
@@ -21,7 +19,6 @@ export type ResolverProps = Parameters<ResolveFx>[0]
 
 export const state = {
   got: null as Got,
-  hasSrc: null as boolean,
   srcDir: null as string
 }
 
@@ -30,15 +27,5 @@ export const initializeState = async (props: ResolverProps) => {
     state.got = (await import("got")).default
   }
 
-  if (state.hasSrc === null) {
-    state.srcDir = resolve(
-      props.options.cacheDir,
-      "../../..",
-      process.env.PLASMO_SRC_PATH || "src"
-    )
-
-    state.hasSrc = existsSync(state.srcDir)
-
-    state.srcDir = state.hasSrc ? state.srcDir : resolve(state.srcDir, "..")
-  }
+  state.srcDir = process.env.PLASMO_SRC_DIR
 }

--- a/packages/parcel-transformer-manifest/package.json
+++ b/packages/parcel-transformer-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasmohq/parcel-transformer-manifest",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Plasmo Parcel Transformer for Web Extension Manifest",
   "files": [
     "dist",

--- a/packages/parcel-transformer-manifest/src/state.ts
+++ b/packages/parcel-transformer-manifest/src/state.ts
@@ -6,7 +6,6 @@ import type {
   MutableAsset,
   TransformerResult
 } from "@parcel/types"
-import { existsSync } from "fs"
 import { dirname, resolve } from "path"
 
 import type { MV2Data, ManifestData } from "./schema"
@@ -72,13 +71,9 @@ export const initState = (
   state.staticDir = resolve(state.dotPlasmoDir, "static")
   state.projectDir = resolve(state.dotPlasmoDir, "..")
 
-  const srcDir = resolve(
-    state.projectDir,
-    process.env.PLASMO_SRC_PATH || "src"
-  )
-  state.srcDir = existsSync(srcDir) ? srcDir : state.projectDir
-
   state.assetsDir = resolve(state.projectDir, "assets")
+
+  state.srcDir = process.env.PLASMO_SRC_DIR
 
   state.ptrs = ptrs
   state.asset = asset

--- a/packages/parcel-transformer-manifest/src/state.ts
+++ b/packages/parcel-transformer-manifest/src/state.ts
@@ -72,7 +72,7 @@ export const initState = (
   state.staticDir = resolve(state.dotPlasmoDir, "static")
   state.projectDir = resolve(state.dotPlasmoDir, "..")
 
-  const srcDir = resolve(state.projectDir, "src")
+  const srcDir = resolve(state.projectDir, process.env.PLASMO_SRC_PATH || "src")
   state.srcDir = existsSync(srcDir) ? srcDir : state.projectDir
 
   state.assetsDir = resolve(state.projectDir, "assets")

--- a/packages/parcel-transformer-manifest/src/state.ts
+++ b/packages/parcel-transformer-manifest/src/state.ts
@@ -72,7 +72,10 @@ export const initState = (
   state.staticDir = resolve(state.dotPlasmoDir, "static")
   state.projectDir = resolve(state.dotPlasmoDir, "..")
 
-  const srcDir = resolve(state.projectDir, process.env.PLASMO_SRC_PATH || "src")
+  const srcDir = resolve(
+    state.projectDir,
+    process.env.PLASMO_SRC_PATH || "src"
+  )
   state.srcDir = existsSync(srcDir) ? srcDir : state.projectDir
 
   state.assetsDir = resolve(state.projectDir, "assets")


### PR DESCRIPTION
_Quick note: Giving `plasmo` another go - having a great experience so far!_

I've added environment variable `PLASMO_SRC_PATH` to override `"src"` so we can put all of our Plasmo entry points (ie. `content.ts`/`background.ts`) inside `./src/extension` instead of cluttering the `./src` directory.

Alternative options:

 - adding command line option `plasmo dev --src-dir src/extension`
 - adding `plasmo.config.js`:
```js
  // plasmo.config.js
  const path = require('path');

  module.exports = { 
    sourceDirectory: path.resolve(process.cwd(), 'src/extension') 
  }
```
 
This would be a real QOL upgrade for us. I appreciate this is a quick 'n' easy hack but would be grateful for the merge now & replace whith a better solution down the line.

## Details

- [x] closes https://discord.com/channels/946290204443025438/978320682985349130/1024646012083642471

### Code of Conduct

- [x] I agree to follow this project's Code of Conduct
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.
