### PR TITLE
fix: allow up to 4 integers in version

### DIFF
--- a/packages/parcel-transformer-manifest/package.json
+++ b/packages/parcel-transformer-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasmohq/parcel-transformer-manifest",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Plasmo Parcel Transformer for Web Extension Manifest",
   "files": [
     "dist",

--- a/packages/parcel-transformer-manifest/src/schema.ts
+++ b/packages/parcel-transformer-manifest/src/schema.ts
@@ -2,7 +2,7 @@ import type { FromSchema } from "json-schema-to-ts"
 
 const validateVersion = (ver: string): string | null | undefined => {
   const parts = ver.split(".")
-  if (parts.length > 4) return "Extension versions to have at most three dots"
+  if (parts.length > 4) return "Extension versions to have at most four dots"
 
   if (
     parts.some((part) => {

--- a/packages/parcel-transformer-manifest/src/schema.ts
+++ b/packages/parcel-transformer-manifest/src/schema.ts
@@ -1,8 +1,8 @@
 import type { FromSchema } from "json-schema-to-ts"
 
-const validateVersion = (ver: string): string | null | undefined => {
+const validateBrowserVersion = (ver: string): string | null | undefined => {
   const parts = ver.split(".")
-  if (parts.length > 4) return "Extension versions to have at most four dots"
+  if (parts.length > 4) return "Browser versions to have at most four dots"
 
   if (
     parts.some((part) => {
@@ -10,7 +10,20 @@ const validateVersion = (ver: string): string | null | undefined => {
       return !isNaN(num) && num < 0 && num > 65536
     })
   )
-    return "Extension versions must be dot-separated integers between 0 and 65535"
+    return "Browser versions must be dot-separated integers between 0 and 65535"
+}
+
+const validateSemver = (ver: string): string | null | undefined => {
+  const parts = ver.split(".")
+  if (parts.length > 3) return "Semantic versions to have at most three dots"
+
+  if (
+    parts.some((part) => {
+      const num = Number(part)
+      return !isNaN(num) && num < 0 && num > 65536
+    })
+  )
+    return "Semantic versions must be dot-separated integers between 0 and 65535"
 }
 
 const stringSchema = {
@@ -87,7 +100,7 @@ const commonProps = {
   name: stringSchema,
   version: {
     type: "string",
-    __validate: validateVersion
+    __validate: validateSemver
   },
   default_locale: stringSchema,
   description: stringSchema,
@@ -261,7 +274,7 @@ const commonProps = {
   key: stringSchema,
   minimum_chrome_version: {
     type: "string",
-    __validate: validateVersion
+    __validate: validateBrowserVersion
   },
   // No NaCl modules because deprecated
   oauth2: {

--- a/packages/parcel-transformer-manifest/src/schema.ts
+++ b/packages/parcel-transformer-manifest/src/schema.ts
@@ -1,30 +1,9 @@
 import type { FromSchema } from "json-schema-to-ts"
 
-const validateBrowserVersion = (ver: string): string | null | undefined => {
-  const parts = ver.split(".")
-  if (parts.length > 4) return "Browser versions to have at most four dots"
-
-  if (
-    parts.some((part) => {
-      const num = Number(part)
-      return !isNaN(num) && num < 0 && num > 65536
-    })
-  )
-    return "Browser versions must be dot-separated integers between 0 and 65535"
-}
-
-const validateSemver = (ver: string): string | null | undefined => {
-  const parts = ver.split(".")
-  if (parts.length > 3) return "Semantic versions to have at most three dots"
-
-  if (
-    parts.some((part) => {
-      const num = Number(part)
-      return !isNaN(num) && num < 0 && num > 65536
-    })
-  )
-    return "Semantic versions must be dot-separated integers between 0 and 65535"
-}
+import {
+  validateBrowserVersion,
+  validateSemanticVersion
+} from "./validate-version"
 
 const stringSchema = {
   type: "string"
@@ -100,7 +79,7 @@ const commonProps = {
   name: stringSchema,
   version: {
     type: "string",
-    __validate: validateSemver
+    __validate: validateSemanticVersion
   },
   default_locale: stringSchema,
   description: stringSchema,

--- a/packages/parcel-transformer-manifest/src/schema.ts
+++ b/packages/parcel-transformer-manifest/src/schema.ts
@@ -2,7 +2,7 @@ import type { FromSchema } from "json-schema-to-ts"
 
 const validateVersion = (ver: string): string | null | undefined => {
   const parts = ver.split(".")
-  if (parts.length > 3) return "Extension versions to have at most three dots"
+  if (parts.length > 4) return "Extension versions to have at most three dots"
 
   if (
     parts.some((part) => {

--- a/packages/parcel-transformer-manifest/src/validate-version.ts
+++ b/packages/parcel-transformer-manifest/src/validate-version.ts
@@ -1,0 +1,24 @@
+const isInvalidVersion = (parts: string[]) =>
+  parts.some((part) => {
+    const num = Number(part)
+    return !isNaN(num) && num < 0 && num > 65536
+  })
+
+const validateVersion = (ver: string, maxSize = 3, name = "Browser") => {
+  const parts = ver.split(".")
+  if (parts.length > maxSize) {
+    return `${name} versions to have at most ${maxSize} dots`
+  }
+
+  if (isInvalidVersion(parts)) {
+    return `${name} versions must be dot-separated integers between 0 and 65535`
+  }
+
+  return undefined
+}
+
+export const validateSemanticVersion = (ver: string) =>
+  validateVersion(ver, 3, "Semantic")
+
+export const validateBrowserVersion = (ver: string) =>
+  validateVersion(ver, 4, "Browser")

--- a/packages/parcel-transformer-manifest/src/validate-version.ts
+++ b/packages/parcel-transformer-manifest/src/validate-version.ts
@@ -1,7 +1,10 @@
+const MIN_VERSION = 0
+const MAX_VERSION = 65535
+
 const isInvalidVersion = (parts: string[]) =>
   parts.some((part) => {
     const num = Number(part)
-    return !isNaN(num) && num < 0 && num > 65536
+    return !isNaN(num) && num < MIN_VERSION && num > MAX_VERSION + 1
   })
 
 const validateVersion = (ver: string, maxSize = 3, name = "Browser") => {
@@ -11,7 +14,7 @@ const validateVersion = (ver: string, maxSize = 3, name = "Browser") => {
   }
 
   if (isInvalidVersion(parts)) {
-    return `${name} versions must be dot-separated integers between 0 and 65535`
+    return `${name} versions must be dot-separated integers between ${MIN_VERSION} and ${MAX_VERSION}`
   }
 
   return undefined


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Details
As per the following docs, the version specified in the manifest can have up to 4 integers (separated by dots).

https://developer.chrome.com/docs/extensions/mv3/manifest/version/
https://developer.chrome.com/docs/extensions/mv3/manifest/minimum_chrome_version/

The schema currently only allows up to 3, so I updated the validation logic to allow up to 4.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.
