### PR TITLE
fix: polyfill export signature

### DIFF
--- a/packages/parcel-optimizer-terser/tsup.config.ts
+++ b/packages/parcel-optimizer-terser/tsup.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsup"
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/runtimes/*"]
+  entry: ["src/index.ts"]
 })

--- a/packages/parcel-resolver/package.json
+++ b/packages/parcel-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasmohq/parcel-resolver",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Plasmo Parcel Resolver",
   "files": [
     "dist"

--- a/packages/parcel-resolver/src/polyfills/assert.ts
+++ b/packages/parcel-resolver/src/polyfills/assert.ts
@@ -1,1 +1,3 @@
-export * from "assert/build/assert"
+import assert from "assert"
+
+export default assert

--- a/packages/parcel-resolver/src/polyfills/assert.ts
+++ b/packages/parcel-resolver/src/polyfills/assert.ts
@@ -1,3 +1,4 @@
-import assert from "assert"
+import assert from "assert/build/assert"
 
+export * from "assert/build/assert"
 export default assert

--- a/packages/parcel-resolver/src/polyfills/buffer.ts
+++ b/packages/parcel-resolver/src/polyfills/buffer.ts
@@ -1,3 +1,4 @@
-import buffer from "buffer"
+import buffer from "buffer/index"
 
+export * from "buffer/index"
 export default buffer

--- a/packages/parcel-resolver/src/polyfills/buffer.ts
+++ b/packages/parcel-resolver/src/polyfills/buffer.ts
@@ -1,1 +1,3 @@
-export * from "buffer"
+import buffer from "buffer"
+
+export default buffer

--- a/packages/parcel-resolver/src/polyfills/console.ts
+++ b/packages/parcel-resolver/src/polyfills/console.ts
@@ -1,1 +1,3 @@
-export * from "console-browserify"
+import console from "console-browserify"
+
+export default console

--- a/packages/parcel-resolver/src/polyfills/console.ts
+++ b/packages/parcel-resolver/src/polyfills/console.ts
@@ -1,3 +1,4 @@
 import console from "console-browserify"
 
+export * from "console-browserify"
 export default console

--- a/packages/parcel-resolver/src/polyfills/crypto.ts
+++ b/packages/parcel-resolver/src/polyfills/crypto.ts
@@ -1,3 +1,4 @@
 import crypto from "crypto-browserify"
 
+export * from "crypto-browserify"
 export default crypto

--- a/packages/parcel-resolver/src/polyfills/crypto.ts
+++ b/packages/parcel-resolver/src/polyfills/crypto.ts
@@ -1,1 +1,3 @@
-export * from "crypto-browserify"
+import crypto from "crypto-browserify"
+
+export default crypto

--- a/packages/parcel-resolver/src/polyfills/domain.ts
+++ b/packages/parcel-resolver/src/polyfills/domain.ts
@@ -1,3 +1,4 @@
 import domain from "domain-browser"
 
+export * from "domain-browser"
 export default domain

--- a/packages/parcel-resolver/src/polyfills/domain.ts
+++ b/packages/parcel-resolver/src/polyfills/domain.ts
@@ -1,1 +1,3 @@
-export * from "domain-browser"
+import domain from "domain-browser"
+
+export default domain

--- a/packages/parcel-resolver/src/polyfills/events.ts
+++ b/packages/parcel-resolver/src/polyfills/events.ts
@@ -1,3 +1,4 @@
 import events from "events/events"
 
+export * from "events/events"
 export default events

--- a/packages/parcel-resolver/src/polyfills/events.ts
+++ b/packages/parcel-resolver/src/polyfills/events.ts
@@ -1,1 +1,3 @@
-export * from "events/events"
+import events from "events/events"
+
+export default events

--- a/packages/parcel-resolver/src/polyfills/http.ts
+++ b/packages/parcel-resolver/src/polyfills/http.ts
@@ -1,3 +1,4 @@
 import http from "stream-http"
 
+export * from "stream-http"
 export default http

--- a/packages/parcel-resolver/src/polyfills/http.ts
+++ b/packages/parcel-resolver/src/polyfills/http.ts
@@ -1,1 +1,3 @@
-export * from "stream-http"
+import http from "stream-http"
+
+export default http

--- a/packages/parcel-resolver/src/polyfills/https.ts
+++ b/packages/parcel-resolver/src/polyfills/https.ts
@@ -1,1 +1,3 @@
-export * from "https-browserify"
+import https from "https-browserify"
+
+export default https

--- a/packages/parcel-resolver/src/polyfills/https.ts
+++ b/packages/parcel-resolver/src/polyfills/https.ts
@@ -1,3 +1,4 @@
 import https from "https-browserify"
 
+export * from "https-browserify"
 export default https

--- a/packages/parcel-resolver/src/polyfills/os.ts
+++ b/packages/parcel-resolver/src/polyfills/os.ts
@@ -1,1 +1,3 @@
-export * from "os-browserify/browser"
+import os from "os-browserify/browser"
+
+export default os

--- a/packages/parcel-resolver/src/polyfills/os.ts
+++ b/packages/parcel-resolver/src/polyfills/os.ts
@@ -1,3 +1,4 @@
 import os from "os-browserify/browser"
 
+export * from "os-browserify/browser"
 export default os

--- a/packages/parcel-resolver/src/polyfills/path.ts
+++ b/packages/parcel-resolver/src/polyfills/path.ts
@@ -1,3 +1,4 @@
 import path from "path-browserify"
 
+export * from "path-browserify"
 export default path

--- a/packages/parcel-resolver/src/polyfills/path.ts
+++ b/packages/parcel-resolver/src/polyfills/path.ts
@@ -1,1 +1,3 @@
-export * from "path-browserify"
+import path from "path-browserify"
+
+export default path

--- a/packages/parcel-resolver/src/polyfills/process.ts
+++ b/packages/parcel-resolver/src/polyfills/process.ts
@@ -1,1 +1,3 @@
-export * from "process/browser"
+import process from "process/browser"
+
+export default process

--- a/packages/parcel-resolver/src/polyfills/process.ts
+++ b/packages/parcel-resolver/src/polyfills/process.ts
@@ -1,3 +1,4 @@
 import process from "process/browser"
 
+export * from "process/browser"
 export default process

--- a/packages/parcel-resolver/src/polyfills/punycode.ts
+++ b/packages/parcel-resolver/src/polyfills/punycode.ts
@@ -1,1 +1,3 @@
-export * from "punycode/punycode.es6"
+import punycode from "punycode/punycode.es6"
+
+export default punycode

--- a/packages/parcel-resolver/src/polyfills/punycode.ts
+++ b/packages/parcel-resolver/src/polyfills/punycode.ts
@@ -1,3 +1,4 @@
 import punycode from "punycode/punycode.es6"
 
+export * from "punycode/punycode.es6"
 export default punycode

--- a/packages/parcel-resolver/src/polyfills/querystring.ts
+++ b/packages/parcel-resolver/src/polyfills/querystring.ts
@@ -1,1 +1,3 @@
-export * from "querystring-es3"
+import querystring from "querystring-es3"
+
+export default querystring

--- a/packages/parcel-resolver/src/polyfills/querystring.ts
+++ b/packages/parcel-resolver/src/polyfills/querystring.ts
@@ -1,3 +1,4 @@
 import querystring from "querystring-es3"
 
+export * from "querystring-es3"
 export default querystring

--- a/packages/parcel-resolver/src/polyfills/stream.ts
+++ b/packages/parcel-resolver/src/polyfills/stream.ts
@@ -1,3 +1,4 @@
 import stream from "stream-browserify"
 
+export * from "stream-browserify"
 export default stream

--- a/packages/parcel-resolver/src/polyfills/stream.ts
+++ b/packages/parcel-resolver/src/polyfills/stream.ts
@@ -1,1 +1,3 @@
-export * from "stream-browserify"
+import stream from "stream-browserify"
+
+export default stream

--- a/packages/parcel-resolver/src/polyfills/string_decoder.ts
+++ b/packages/parcel-resolver/src/polyfills/string_decoder.ts
@@ -1,1 +1,3 @@
-export * from "string_decoder"
+import StringEncoder from "string_decoder"
+
+export default StringEncoder

--- a/packages/parcel-resolver/src/polyfills/string_decoder.ts
+++ b/packages/parcel-resolver/src/polyfills/string_decoder.ts
@@ -1,3 +1,4 @@
-import StringEncoder from "string_decoder"
+import stringDecoder from "string_decoder/lib/string_decoder"
 
-export default StringEncoder
+export * from "string_decoder/lib/string_decoder"
+export default stringDecoder

--- a/packages/parcel-resolver/src/polyfills/sys.ts
+++ b/packages/parcel-resolver/src/polyfills/sys.ts
@@ -1,3 +1,4 @@
-import Sys from "util"
+import sys from "util/util"
 
-export default Sys
+export * from "util/util"
+export default sys

--- a/packages/parcel-resolver/src/polyfills/sys.ts
+++ b/packages/parcel-resolver/src/polyfills/sys.ts
@@ -1,1 +1,3 @@
-export * from "util/util"
+import Sys from "util"
+
+export default Sys

--- a/packages/parcel-resolver/src/polyfills/timers.ts
+++ b/packages/parcel-resolver/src/polyfills/timers.ts
@@ -1,3 +1,4 @@
 import timers from "timers-browserify"
 
+export * from "timers-browserify"
 export default timers

--- a/packages/parcel-resolver/src/polyfills/timers.ts
+++ b/packages/parcel-resolver/src/polyfills/timers.ts
@@ -1,1 +1,3 @@
-export * from "timers-browserify"
+import timers from "timers-browserify"
+
+export default timers

--- a/packages/parcel-resolver/src/polyfills/tty.ts
+++ b/packages/parcel-resolver/src/polyfills/tty.ts
@@ -1,3 +1,4 @@
-import Tty from "tty-browserify"
+import tty from "tty-browserify"
 
-export default Tty
+export * from "tty-browserify"
+export default tty

--- a/packages/parcel-resolver/src/polyfills/tty.ts
+++ b/packages/parcel-resolver/src/polyfills/tty.ts
@@ -1,1 +1,3 @@
-export * from "tty-browserify"
+import Tty from "tty-browserify"
+
+export default Tty

--- a/packages/parcel-resolver/src/polyfills/url.ts
+++ b/packages/parcel-resolver/src/polyfills/url.ts
@@ -1,4 +1,4 @@
-import url from "url"
+import url from "url/url"
 
-export * from "url"
+export * from "url/url"
 export default url

--- a/packages/parcel-resolver/src/polyfills/url.ts
+++ b/packages/parcel-resolver/src/polyfills/url.ts
@@ -1,3 +1,4 @@
-import Url from "url"
+import url from "url"
 
-export default Url
+export * from "url"
+export default url

--- a/packages/parcel-resolver/src/polyfills/url.ts
+++ b/packages/parcel-resolver/src/polyfills/url.ts
@@ -1,1 +1,3 @@
-export * from "url"
+import Url from "url"
+
+export default Url

--- a/packages/parcel-resolver/src/polyfills/util.ts
+++ b/packages/parcel-resolver/src/polyfills/util.ts
@@ -1,1 +1,3 @@
-export * from "util/util"
+import Util from "util"
+
+export default Util

--- a/packages/parcel-resolver/src/polyfills/util.ts
+++ b/packages/parcel-resolver/src/polyfills/util.ts
@@ -1,3 +1,4 @@
-import Util from "util"
+import util from "util"
 
-export default Util
+export * from "util"
+export default util

--- a/packages/parcel-resolver/src/polyfills/util.ts
+++ b/packages/parcel-resolver/src/polyfills/util.ts
@@ -1,4 +1,4 @@
-import util from "util"
+import util from "util/util"
 
-export * from "util"
+export * from "util/util"
 export default util

--- a/packages/parcel-resolver/src/polyfills/vm.ts
+++ b/packages/parcel-resolver/src/polyfills/vm.ts
@@ -1,1 +1,3 @@
-export * from "vm-browserify"
+import vm from "vm-browserify"
+
+export default vm

--- a/packages/parcel-resolver/src/polyfills/vm.ts
+++ b/packages/parcel-resolver/src/polyfills/vm.ts
@@ -1,3 +1,4 @@
 import vm from "vm-browserify"
 
+export * from "vm-browserify"
 export default vm

--- a/packages/parcel-resolver/src/polyfills/zlib.ts
+++ b/packages/parcel-resolver/src/polyfills/zlib.ts
@@ -1,1 +1,3 @@
-export * from "browserify-zlib"
+import zlib from "browserify-zlib"
+
+export default zlib

--- a/packages/parcel-resolver/src/polyfills/zlib.ts
+++ b/packages/parcel-resolver/src/polyfills/zlib.ts
@@ -1,3 +1,4 @@
 import zlib from "browserify-zlib"
 
+export * from "browserify-zlib"
 export default zlib


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Details

This PR fix the export for nodejs browserified polyfill.

Most module that consumes these polyfill do it like this:

```
import Buffer from "buffer"
```

However, our `export *` strategy doesn't have a `default` export, causing issue for downstream user and peer dependency

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.
