### PR TITLE
feat: prioritize local alias resolution above polyfill

### DIFF
--- a/cli/create-plasmo/package.json
+++ b/cli/create-plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-plasmo",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "description": "Create Plasmo Framework Browser Extension",
   "main": "dist/index.js",
   "bin": "bin/index.mjs",

--- a/cli/plasmo/package.json
+++ b/cli/plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plasmo",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "description": "The Plasmo Platform CLI",
   "main": "dist/index.js",
   "types": "dist/type.d.ts",

--- a/packages/parcel-config/package.json
+++ b/packages/parcel-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasmohq/parcel-config",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/parcel-resolver/index.mjs
+++ b/packages/parcel-resolver/index.mjs
@@ -3,7 +3,7 @@ import glob from "fast-glob"
 
 const commonConfig = {
   bundle: true,
-  minify: true,
+  // minify: true,
 
   platform: "browser",
   format: "cjs",

--- a/packages/parcel-resolver/package.json
+++ b/packages/parcel-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasmohq/parcel-resolver",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "description": "Plasmo Parcel Resolver",
   "files": [
     "dist"
@@ -29,8 +29,8 @@
     "@plasmo/utils": "workspace:*",
     "@plasmohq/rps": "workspace:*",
     "assert": "2.0.0",
-    "browserify-zlib": "0.2.0",
     "buffer": "6.0.3",
+    "browserify-zlib": "0.2.0",
     "console-browserify": "1.2.0",
     "constants-browserify": "1.0.0",
     "crc-32": "1.2.2",
@@ -48,7 +48,6 @@
     "stream-browserify": "3.0.0",
     "stream-http": "3.2.0",
     "string_decoder": "1.3.0",
-    "timers": "0.1.1",
     "timers-browserify": "2.0.12",
     "tsup": "6.5.0",
     "tty-browserify": "0.0.1",
@@ -62,6 +61,7 @@
     "@parcel/plugin": "2.8.3",
     "@parcel/types": "2.8.3",
     "fast-glob": "3.2.12",
+    "fs-extra": "11.1.0",
     "got": "12.5.3"
   }
 }

--- a/packages/parcel-resolver/src/handle-alias.ts
+++ b/packages/parcel-resolver/src/handle-alias.ts
@@ -1,0 +1,26 @@
+import { resolve } from "path"
+
+import { isFileOk } from "@plasmo/utils/fs"
+
+import { ResolverProps, ResolverResult, state } from "./shared"
+
+export async function handleAlias({
+  specifier
+}: ResolverProps): Promise<ResolverResult> {
+  if (!state.aliasMap.has(specifier)) {
+    return null
+  }
+
+  const absPath = resolve(state.aliasMap.get(specifier))
+
+  const hasLocalAlias = await isFileOk(absPath)
+
+  if (!hasLocalAlias) {
+    return null
+  }
+
+  return {
+    filePath: absPath,
+    priority: "sync"
+  }
+}

--- a/packages/parcel-resolver/src/handle-module-exports.ts
+++ b/packages/parcel-resolver/src/handle-module-exports.ts
@@ -1,5 +1,7 @@
 import type { ResolverProps, ResolverResult } from "./shared"
 
+const knownEsmPackageSet = new Set(["firebase-admin"])
+
 export async function handleModuleExport({
   specifier,
   dependency
@@ -7,7 +9,7 @@ export async function handleModuleExport({
   try {
     const segments = specifier.split("/")
 
-    if (segments.length > 2) {
+    if (segments.length > 2 || knownEsmPackageSet.has(segments[0])) {
       const filePath = require.resolve(specifier, {
         paths: [dependency.resolveFrom]
       })

--- a/packages/parcel-resolver/src/index.ts
+++ b/packages/parcel-resolver/src/index.ts
@@ -1,18 +1,20 @@
 import { Resolver } from "@parcel/plugin"
 
 import { handleAbsoluteRoot } from "./handle-absolute-root"
+import { handleAlias } from "./handle-alias"
 import { handleModuleExport } from "./handle-module-exports"
 import { handlePlasmoInternal } from "./handle-plasmo-internal"
 import { handlePolyfill } from "./handle-polyfill"
 import { handleRemoteCaching } from "./handle-remote-caching"
 import { handleTildeSrc } from "./handle-tilde-src"
-import { initializeState } from "./shared"
+import { initializeState, state } from "./shared"
 
 export default new Resolver({
   async resolve(props) {
     await initializeState(props)
 
     return (
+      (await handleAlias(props)) ||
       (await handlePlasmoInternal(props)) ||
       (await handlePolyfill(props)) ||
       (await handleRemoteCaching(props)) ||

--- a/packages/parcel-resolver/src/shared.ts
+++ b/packages/parcel-resolver/src/shared.ts
@@ -2,6 +2,7 @@ import type { Resolver } from "@parcel/plugin"
 import type { ResolveResult } from "@parcel/types"
 import glob from "fast-glob"
 import { statSync } from "fs"
+import { readJson } from "fs-extra"
 import type { Got } from "got"
 import { join, resolve } from "path"
 
@@ -26,7 +27,8 @@ export type ResolverProps = Parameters<ResolveFx>[0]
 export const state = {
   got: null as Got,
   dotPlasmoDirectory: null as string,
-  polyfillMap: null as Map<string, string>
+  polyfillMap: null as Map<string, string>,
+  aliasMap: null as Map<string, string>
 }
 
 export const initializeState = async (props: ResolverProps) => {
@@ -54,6 +56,14 @@ export const initializeState = async (props: ResolverProps) => {
         join(polyfillsDirectory, handler)
       ])
     )
+  }
+
+  if (!state.aliasMap) {
+    const packageJson = await readJson(
+      resolve(process.env.PLASMO_PROJECT_DIR, "package.json")
+    )
+
+    state.aliasMap = new Map(Object.entries(packageJson.alias || {}))
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1497,6 +1497,7 @@ importers:
       esbuild: 0.17.3
       events: 3.3.0
       fast-glob: 3.2.12
+      fs-extra: 11.1.0
       got: 12.5.3
       https-browserify: 1.0.0
       os-browserify: 0.3.0
@@ -1508,7 +1509,6 @@ importers:
       stream-browserify: 3.0.0
       stream-http: 3.2.0
       string_decoder: 1.3.0
-      timers: 0.1.1
       timers-browserify: 2.0.12
       tsup: 6.5.0
       tty-browserify: 0.0.1
@@ -1521,6 +1521,7 @@ importers:
       '@parcel/plugin': 2.8.3_@parcel+core@2.8.3
       '@parcel/types': 2.8.3_@parcel+core@2.8.3
       fast-glob: 3.2.12
+      fs-extra: 11.1.0
       got: 12.5.3
     devDependencies:
       '@plasmo/config': link:../config
@@ -1546,7 +1547,6 @@ importers:
       stream-browserify: 3.0.0
       stream-http: 3.2.0
       string_decoder: 1.3.0
-      timers: 0.1.1
       timers-browserify: 2.0.12
       tsup: 6.5.0
       tty-browserify: 0.0.1
@@ -7774,7 +7774,6 @@ packages:
       graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
-    dev: true
 
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -9167,7 +9166,6 @@ packages:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.10
-    dev: true
 
   /jsx-ast-utils/3.3.3:
     resolution: {integrity: sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==}
@@ -12029,10 +12027,6 @@ packages:
       setimmediate: 1.0.5
     dev: true
 
-  /timers/0.1.1:
-    resolution: {integrity: sha512-pkJC8uIP/gxDHxNQUBUbjHyl6oZfT+ofn7tbaHW+CFIUjI+Q2MBbHcx1JSBQfhDaTcO9bNg328q0i7Vk5PismQ==}
-    dev: true
-
   /timsort/0.3.0:
     resolution: {integrity: sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==}
     dev: false
@@ -12387,7 +12381,6 @@ packages:
   /universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
-    dev: true
 
   /update-browserslist-db/1.0.10_browserslist@4.21.4:
     resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Details

This PR parse the alias list upfront in our custom resolver and short-circuit the parcel resolver default polyfill. This allows us to easily patch packages via alias, with TS!

It also bypass the ESM resolver on Parcel'end with the node resolver, allow known ESM module to just work.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.
