### PR TITLE
fix(cli): typo on cli author name prompt

### DIFF
--- a/cli/plasmo/src/features/project-creator/index.ts
+++ b/cli/plasmo/src/features/project-creator/index.ts
@@ -200,7 +200,7 @@ export class ProjectCreator {
       packageData.author = "Plasmo Corp. <foss@plasmo.com>"
     } else {
       delete packageData.contributors
-      packageData.author = await quickPrompt("Auhor name:", packageData.author)
+      packageData.author = await quickPrompt("Author name:", packageData.author)
 
       if (resolveWorkspaceRefs) {
         vLog(


### PR DESCRIPTION
## Details
-  Minor typo fix on CLI's `Author Name` prompt

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.
