### PR TITLE
fix: loading indicator styles clashing with the commonly used 'hidden' class

### DIFF
--- a/packages/parcel-runtime/src/utils/loading-indicator.ts
+++ b/packages/parcel-runtime/src/utils/loading-indicator.ts
@@ -32,19 +32,19 @@ function createLoadingEl() {
       }
     }
     
-    .svg-elem-1 {
+    #${LOADING_ID} .svg-elem-1 {
       animation: animate-svg-fill 1.47s cubic-bezier(0.47, 0, 0.745, 0.715) 0.8s both infinite;
     }
 
-    .svg-elem-2 {
+    #${LOADING_ID} .svg-elem-2 {
       animation: animate-svg-fill 1.47s cubic-bezier(0.47, 0, 0.745, 0.715) 0.9s both infinite;
     }
     
-    .svg-elem-3 {
+    #${LOADING_ID} .svg-elem-3 {
       animation: animate-svg-fill 1.47s cubic-bezier(0.47, 0, 0.745, 0.715) 1s both infinite;
     }
 
-    .hidden {
+    #${LOADING_ID} .hidden {
       display: none;
     }
 


### PR DESCRIPTION


<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Details

The loading indicator element defined a "hidden" CSS class that didn't work well with libraries like tailwind, breaking the plasma website among others when developing locally. The issue was described in #499.

In this PR, I added the `LOADING_ID` as a prefix to all the styles so that there is no conflict between the class names.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.
