### PR TITLE
feat: Support paths in nested (extends) tsconfigs

### DIFF
--- a/cli/create-plasmo/package.json
+++ b/cli/create-plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-plasmo",
-  "version": "0.67.5",
+  "version": "0.68.0",
   "description": "Create Plasmo Framework Browser Extension",
   "main": "dist/index.js",
   "bin": "bin/index.mjs",

--- a/cli/plasmo/package.json
+++ b/cli/plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plasmo",
-  "version": "0.67.5",
+  "version": "0.68.0",
   "description": "The Plasmo Platform CLI",
   "main": "dist/index.js",
   "types": "dist/type.d.ts",

--- a/packages/parcel-config/package.json
+++ b/packages/parcel-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasmohq/parcel-config",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/parcel-resolver-post/package.json
+++ b/packages/parcel-resolver-post/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasmohq/parcel-resolver-post",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "Plasmo Parcel Resolver Post-processing",
   "files": [
     "dist"


### PR DESCRIPTION
## Details

This PR adds support for finding tsconfig paths from tsconfigs that use `extends`.

I originally posted in discord asking if it was possible to use plasmo in an nx monorepo (https://discord.com/channels/946290204443025438/1088301075871830067). It didn't seem to be possible, but after looking at the code a bit I thought it might not be too hard to add support. This PR is an initial attempt at that.

I haven't done any testing beyond my use case, so this PR is - at least currently - just asking "is this something you would be interested in supporting?" and not "I'm confident these changes are good".

For a quick tl;dr of my changes: I updated the way paths from tsconfig files were being loaded to recursively follow parent configs specified by `extends`. Additionally, I updated the way `tsPathsMap` is constructed to join all of the paths from all of the relevant tsconfig files.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

