### PR TITLE
feat: Layout or globalProvider for React runtime

### DIFF
--- a/cli/plasmo/templates/static/common/react.ts
+++ b/cli/plasmo/templates/static/common/react.ts
@@ -1,0 +1,8 @@
+import { type FC, Fragment, type ReactNode } from "react"
+
+export const getLayout = (RawImport: any): FC<{ children: ReactNode }> =>
+  typeof RawImport.Layout === "function"
+    ? RawImport.Layout
+    : typeof RawImport.getGlobalProvider === "function"
+    ? RawImport.getGlobalProvider()
+    : Fragment

--- a/cli/plasmo/templates/static/react17/content-script-ui-mount.tsx
+++ b/cli/plasmo/templates/static/react17/content-script-ui-mount.tsx
@@ -22,12 +22,17 @@ const render = createRender(
   [InlineCSUIContainer, OverlayCSUIContainer],
   observer?.mountState,
   async (anchor, rootContainer) => {
+    const Layout =
+      RawMount.Layout || RawMount.getGlobalProvider?.() || React.Fragment
+
     switch (anchor.type) {
       case "inline": {
         ReactDOM.render(
-          <InlineCSUIContainer anchor={anchor}>
-            <RawMount.default anchor={anchor} />
-          </InlineCSUIContainer>,
+          <Layout>
+            <InlineCSUIContainer anchor={anchor}>
+              <RawMount.default anchor={anchor} />
+            </InlineCSUIContainer>
+          </Layout>,
           rootContainer
         )
         break
@@ -46,13 +51,15 @@ const render = createRender(
                 type: "overlay"
               }
               return (
-                <OverlayCSUIContainer
-                  id={id}
-                  key={id}
-                  anchor={innerAnchor}
-                  watchOverlayAnchor={Mount.watchOverlayAnchor}>
-                  <RawMount.default anchor={innerAnchor} />
-                </OverlayCSUIContainer>
+                <Layout>
+                  <OverlayCSUIContainer
+                    id={id}
+                    key={id}
+                    anchor={innerAnchor}
+                    watchOverlayAnchor={Mount.watchOverlayAnchor}>
+                    <RawMount.default anchor={innerAnchor} />
+                  </OverlayCSUIContainer>
+                </Layout>
               )
             })}
           </>,

--- a/cli/plasmo/templates/static/react17/content-script-ui-mount.tsx
+++ b/cli/plasmo/templates/static/react17/content-script-ui-mount.tsx
@@ -10,6 +10,8 @@ import * as ReactDOM from "react-dom"
 // @ts-ignore
 import * as RawMount from "__plasmo_mount_content_script__"
 
+import { getLayout } from "@plasmo-static-common/react"
+
 import type { PlasmoCSUI, PlasmoCSUIAnchor } from "~type"
 
 // Escape parcel's static analyzer
@@ -22,8 +24,7 @@ const render = createRender(
   [InlineCSUIContainer, OverlayCSUIContainer],
   observer?.mountState,
   async (anchor, rootContainer) => {
-    const Layout =
-      RawMount.Layout || RawMount.getGlobalProvider?.() || React.Fragment
+    const Layout = getLayout(RawMount)
 
     switch (anchor.type) {
       case "inline": {

--- a/cli/plasmo/templates/static/react17/index.tsx
+++ b/cli/plasmo/templates/static/react17/index.tsx
@@ -10,6 +10,15 @@ document.addEventListener("DOMContentLoaded", () => {
     return
   }
 
+  const Layout =
+    Component.Layout || Component.getGlobalProvider?.() || React.Fragment
+
   __plasmoRoot = document.getElementById("__plasmo")
-  ReactDOM.render(<Component.default />, __plasmoRoot)
+
+  ReactDOM.render(
+    <Layout>
+      <Component.default />
+    </Layout>,
+    __plasmoRoot
+  )
 })

--- a/cli/plasmo/templates/static/react17/index.tsx
+++ b/cli/plasmo/templates/static/react17/index.tsx
@@ -1,4 +1,5 @@
-// @ts-nocheck
+import { getLayout } from "@plasmo-static-common/react"
+// @ts-ignore
 import * as Component from "__plasmo_import_module__"
 import React from "react"
 import * as ReactDOM from "react-dom"
@@ -10,8 +11,7 @@ document.addEventListener("DOMContentLoaded", () => {
     return
   }
 
-  const Layout =
-    Component.Layout || Component.getGlobalProvider?.() || React.Fragment
+  const Layout = getLayout(Component)
 
   __plasmoRoot = document.getElementById("__plasmo")
 

--- a/cli/plasmo/templates/static/react18/content-script-ui-mount.tsx
+++ b/cli/plasmo/templates/static/react18/content-script-ui-mount.tsx
@@ -23,12 +23,18 @@ const render = createRender(
   observer?.mountState,
   async (anchor, rootContainer) => {
     const root = createRoot(rootContainer)
+
+    const Layout =
+      RawMount.Layout || RawMount.getGlobalProvider?.() || React.Fragment
+
     switch (anchor.type) {
       case "inline": {
         root.render(
-          <InlineCSUIContainer anchor={anchor}>
-            <RawMount.default anchor={anchor} />
-          </InlineCSUIContainer>
+          <Layout>
+            <InlineCSUIContainer anchor={anchor}>
+              <RawMount.default anchor={anchor} />
+            </InlineCSUIContainer>
+          </Layout>
         )
         break
       }
@@ -46,13 +52,15 @@ const render = createRender(
                 type: "overlay"
               }
               return (
-                <OverlayCSUIContainer
-                  id={id}
-                  key={id}
-                  anchor={innerAnchor}
-                  watchOverlayAnchor={Mount.watchOverlayAnchor}>
-                  <RawMount.default anchor={innerAnchor} />
-                </OverlayCSUIContainer>
+                <Layout>
+                  <OverlayCSUIContainer
+                    id={id}
+                    key={id}
+                    anchor={innerAnchor}
+                    watchOverlayAnchor={Mount.watchOverlayAnchor}>
+                    <RawMount.default anchor={innerAnchor} />
+                  </OverlayCSUIContainer>
+                </Layout>
               )
             })}
           </>

--- a/cli/plasmo/templates/static/react18/content-script-ui-mount.tsx
+++ b/cli/plasmo/templates/static/react18/content-script-ui-mount.tsx
@@ -3,6 +3,7 @@ import {
   InlineCSUIContainer,
   OverlayCSUIContainer
 } from "@plasmo-static-common/csui-container-react"
+import { getLayout } from "@plasmo-static-common/react"
 import React from "react"
 import { createRoot } from "react-dom/client"
 
@@ -24,8 +25,7 @@ const render = createRender(
   async (anchor, rootContainer) => {
     const root = createRoot(rootContainer)
 
-    const Layout =
-      RawMount.Layout || RawMount.getGlobalProvider?.() || React.Fragment
+    const Layout = getLayout(RawMount)
 
     switch (anchor.type) {
       case "inline": {

--- a/cli/plasmo/templates/static/react18/index.tsx
+++ b/cli/plasmo/templates/static/react18/index.tsx
@@ -1,4 +1,5 @@
-// @ts-nocheck
+import { getLayout } from "@plasmo-static-common/react"
+// @ts-ignore
 import * as Component from "__plasmo_import_module__"
 import React from "react"
 import { createRoot } from "react-dom/client"
@@ -14,8 +15,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const root = createRoot(__plasmoRoot)
 
-  const Layout =
-    Component.Layout || Component.getGlobalProvider?.() || React.Fragment
+  const Layout = getLayout(Component)
 
   root.render(
     <Layout>

--- a/cli/plasmo/templates/static/react18/index.tsx
+++ b/cli/plasmo/templates/static/react18/index.tsx
@@ -11,6 +11,15 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   __plasmoRoot = document.getElementById("__plasmo")
+
   const root = createRoot(__plasmoRoot)
-  root.render(<Component.default />)
+
+  const Layout =
+    Component.Layout || Component.getGlobalProvider?.() || React.Fragment
+
+  root.render(
+    <Layout>
+      <Component.default />
+    </Layout>
+  )
 })


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR introduces a new `getGlobalProvider` function for React runtime. This function is aliased with `Layout` to align with some convention from other framework. Thus, user can either do as the RFC described, or this:

```
export const Layout = () => // return a provider here
```

or
```
export const Layout = Provider
```

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
