### PR TITLE
fix: React templates overlay list array keys fix

### DIFF
--- a/cli/plasmo/templates/static/react17/content-script-ui-mount.tsx
+++ b/cli/plasmo/templates/static/react17/content-script-ui-mount.tsx
@@ -52,10 +52,9 @@ const render = createRender(
                 type: "overlay"
               }
               return (
-                <Layout>
+                <Layout key={id}>
                   <OverlayCSUIContainer
                     id={id}
-                    key={id}
                     anchor={innerAnchor}
                     watchOverlayAnchor={Mount.watchOverlayAnchor}>
                     <RawMount.default anchor={innerAnchor} />

--- a/cli/plasmo/templates/static/react18/content-script-ui-mount.tsx
+++ b/cli/plasmo/templates/static/react18/content-script-ui-mount.tsx
@@ -52,10 +52,9 @@ const render = createRender(
                 type: "overlay"
               }
               return (
-                <Layout>
+                <Layout key={id}>
                   <OverlayCSUIContainer
                     id={id}
-                    key={id}
                     anchor={innerAnchor}
                     watchOverlayAnchor={Mount.watchOverlayAnchor}>
                     <RawMount.default anchor={innerAnchor} />


### PR DESCRIPTION
## Details

This PR fixes React component keys in an array in templates - moved them to the outermost component.



### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.
