### PR TITLE
Add await to sendMessage

### DIFF
--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -34,7 +34,7 @@ export const sendToContentScript: PlasmoMessaging.SendFx = async (req) => {
   const tabId =
     typeof req.tabId === "number" ? req.tabId : (await getActiveTab()).id
 
-  return chrome.tabs.sendMessage(tabId, req)
+  return await chrome.tabs.sendMessage(tabId, req)
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

I used the `sendToContentScript` method from popup.tsx, but the response is always undefined. I suspect that this is because the Promise of chrome.tabs.sendMessage is not being resolved

```popup.tsx
// popup.tsx
const res = await sendToContentScript({
    name: "foo",
    body: {},
})
console.log(res) // undefined.
```

```content.ts
// content.ts
chrome.runtime.onMessage.addListener(async (message, _, sendResponse) => {
  if(message.name === "foo") {
      await anyFunc()
      sendResponse({ status: "ok" })
   }
})
```
### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts
Discord ID: 449552442124795906
