### PR TITLE
feat: multiple content scripts with index files

### DIFF
--- a/cli/plasmo/src/features/manifest-factory/base.ts
+++ b/cli/plasmo/src/features/manifest-factory/base.ts
@@ -430,7 +430,7 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
       .then((results) => results.includes(true))
   }
 
-  addContentScriptsNestedDirectories = async () => {
+  addContentScriptsIndexFiles = async () => {
     const path = this.projectPath.contentsDirectory
 
     const indexFileList = [...this.#extSet].flatMap((ext) => [
@@ -459,7 +459,7 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
   ) =>
     Promise.all([
       this.addDirectory(contentsDirectory, this.toggleContentScript),
-      this.addContentScriptsNestedDirectories()
+      this.addContentScriptsIndexFiles()
     ]).then((results) => results.includes(true))
 
   togglePage = async (path?: string, enable = false) => {

--- a/cli/plasmo/src/features/manifest-factory/base.ts
+++ b/cli/plasmo/src/features/manifest-factory/base.ts
@@ -35,7 +35,7 @@ import {
 } from "@plasmo/framework-shared/build-socket"
 import { assertTruthy } from "@plasmo/utils/assert"
 import { injectEnv } from "@plasmo/utils/env"
-import { isReadable } from "@plasmo/utils/fs"
+import { isDirectory, isReadable } from "@plasmo/utils/fs"
 import { vLog } from "@plasmo/utils/logging"
 import { getSubExt, toPosix } from "@plasmo/utils/path"
 
@@ -432,6 +432,9 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
 
   addContentScriptsIndexFiles = async () => {
     const path = this.projectPath.contentsDirectory
+    if (!(await isDirectory(path))) {
+      return false
+    }
 
     const indexFileList = [...this.#extSet].flatMap((ext) => [
       `index${ext}`,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR implements #613, allowing for content scripts to be defined via `index.ts` files within the `contents` directory - for example:
```
src
└── contents
    ├── another-valid-script
    │   ├── utils.ts
    │   └── index.tsx
    └── valid-script.ts
```

See the original issue for more context / how this mirrors existing functionality.

## Implementation

My current approach is fairly straightforward - in addition to shallowly scanning for files within `contents`, `addContentScriptsNestedDirectories` now handles also scanning shallow directories for any index-like files within them. From what I can tell, simply calling `toggleContentScript` on these nested files behaves as expected and registers the scripts 🎉 

A few other things I tested (though please double check me!):
- dev file watching works as expected, including for non-entrypoint modules like `utils.ts` in the above tree example)
- there doesn't seem to be any collision issues between files (say, `contents/foo.ts`) and directories (`contents/foo/index.ts`) - these appear to be registered as independent scripts. I'd assume that's desired behavior, but let me know if we want some other conflict resolution strategy
- Content Scripts UI files also work as expected
- browser-specific entrypoints (i.e. `contents/foo/index.chrome.ts`) are handled with the same logic as shallow files

Opening this as a draft PR for now, since I'm not entirely settled on this implementation approach - just wanted to get something up to start iterating.

## Naming

I've been referring to this case as "nested directories", though I think that's a bit misleading since it's really only one level deep. If there's a better name we should use here let me know and I can update code accordingly!

## Example

I've been using a standalone example project for my local testing, though I'm happy to create a more formal example if that's easier for review / demonstrating! Let me know what works best.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: aeroencychris

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
