### PR TITLE
feat: Inject sfc style to csui root when using vue(#675)

### DIFF
--- a/cli/plasmo/src/type.ts
+++ b/cli/plasmo/src/type.ts
@@ -68,7 +68,12 @@ export type PlasmoMountShadowHost = (
 
 export type PlasmoGetShadowHostId = Getter<string, PlasmoCSUIAnchor>
 
-export type PlasmoGetStyle = Getter<HTMLStyleElement, PlasmoCSUIAnchor>
+export type PlasmoGetStyle = Getter<
+  HTMLStyleElement,
+  PlasmoCSUIAnchor & { sfcStyleContent?: string }
+>
+
+export type PlasmoGetSfcStyleContent = Getter<string>
 
 /**
  * @return a cleanup unwatch function that will be run when unmounted
@@ -113,6 +118,7 @@ export type PlasmoCSUIWatch = (props: {
 export type PlasmoCSUI<T> = {
   default: any
   getStyle: PlasmoGetStyle
+  getSfcStyleContent: PlasmoGetSfcStyleContent
   getShadowHostId: PlasmoGetShadowHostId
 
   getOverlayAnchor: PlasmoGetOverlayAnchor

--- a/cli/plasmo/templates/static/common/csui.ts
+++ b/cli/plasmo/templates/static/common/csui.ts
@@ -32,7 +32,11 @@ async function injectAnchor<T>(
   mountState?: PlasmoCSUIMountState
 ) {
   if (typeof Mount.getStyle === "function") {
-    shadowRoot.prepend(await Mount.getStyle(anchor))
+    const sfcStyleContent =
+      typeof Mount.getSfcStyleContent === "function"
+        ? await Mount.getSfcStyleContent()
+        : ""
+    shadowRoot.prepend(await Mount.getStyle({ ...anchor, sfcStyleContent }))
   }
 
   if (typeof Mount.getShadowHostId === "function") {

--- a/cli/plasmo/templates/static/vue3/content-script-ui-mount.ts
+++ b/cli/plasmo/templates/static/vue3/content-script-ui-mount.ts
@@ -10,6 +10,10 @@ import { createApp } from "vue"
 // @ts-ignore
 import RawMount from "__plasmo_mount_content_script__"
 
+// prettier-sort-ignore
+// @ts-ignore
+import SfcStyleContent from "style-raw:__plasmo_mount_content_script__"
+
 import type {
   PlasmoCSUI,
   PlasmoCSUIAnchor,
@@ -17,7 +21,19 @@ import type {
 } from "~type"
 
 // Escape parcel's static analyzer
-const Mount = RawMount.plasmo as PlasmoCSUI<PlasmoCSUIHTMLContainer>
+const Mount = (RawMount.plasmo || {}) as PlasmoCSUI<PlasmoCSUIHTMLContainer>
+
+if (typeof SfcStyleContent === "string") {
+  Mount.getSfcStyleContent = () => SfcStyleContent
+
+  if (typeof Mount.getStyle !== "function") {
+    Mount.getStyle = ({ sfcStyleContent }) => {
+      const element = document.createElement("style")
+      element.textContent = sfcStyleContent
+      return element
+    }
+  }
+}
 
 const observer = createAnchorObserver(Mount)
 

--- a/core/parcel-config/index.json
+++ b/core/parcel-config/index.json
@@ -42,6 +42,7 @@
     "template:*.vue": ["@plasmohq/parcel-transformer-vue"],
     "script:*.vue": ["@plasmohq/parcel-transformer-vue"],
     "style:*.vue": ["@plasmohq/parcel-transformer-vue"],
+    "style-raw:*.vue": ["@plasmohq/parcel-transformer-vue"],
     "custom:*.vue": ["@plasmohq/parcel-transformer-vue"],
 
     "*.svelte": ["@plasmohq/parcel-transformer-svelte"],


### PR DESCRIPTION
## Details

https://github.com/PlasmoHQ/plasmo/issues/675

when using vue...

* Import the raw Sfc style string and define `getSfcStyleContent` in `content-script-ui-mount.ts`
* Add `sfcStyleContent` to the `getStyle` argument and pass the result of `getSfcStyleContent` at call time.
* Define getStyle to inject sfc style when getStyle is not defined
* chore: No error if plasmo object is not exported

Note: `getSfcStyleContent` is not intended to be defined by the user.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
