### PR TITLE
bug: Vue throwing warning in console because  __VUE_OPTIONS_API__ and __VUE_PROD_DEVTOOLS__ are not definede

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist/
 # misc
 .DS_Store
 *.pem
+.idea
 
 # debug
 npm-debug.log*

--- a/cli/create-plasmo/package.json
+++ b/cli/create-plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-plasmo",
-  "version": "0.81.1",
+  "version": "0.82.0",
   "description": "Create Plasmo Framework Browser Extension",
   "main": "dist/index.js",
   "bin": "bin/index.mjs",

--- a/cli/plasmo/package.json
+++ b/cli/plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plasmo",
-  "version": "0.81.1",
+  "version": "0.82.0",
   "description": "The Plasmo Framework CLI",
   "publishConfig": {
     "types": "dist/type.d.ts"

--- a/cli/plasmo/templates/static/common/vue.ts
+++ b/cli/plasmo/templates/static/common/vue.ts
@@ -1,0 +1,5 @@
+if (process.env.NODE_ENV !== "production") {
+  globalThis.__VUE_OPTIONS_API__ = true
+} else {
+  globalThis.__VUE_OPTIONS_API__ = false
+}

--- a/cli/plasmo/templates/static/common/vue.ts
+++ b/cli/plasmo/templates/static/common/vue.ts
@@ -1,5 +1,2 @@
-if (process.env.NODE_ENV !== "production") {
-  globalThis.__VUE_OPTIONS_API__ = true
-} else {
-  globalThis.__VUE_OPTIONS_API__ = false
-}
+globalThis.__VUE_OPTIONS_API__ = true
+globalThis.__VUE_PROD_DEVTOOLS__ = process.env.NODE_ENV !== "production"

--- a/cli/plasmo/templates/static/vue3/content-script-ui-mount.ts
+++ b/cli/plasmo/templates/static/vue3/content-script-ui-mount.ts
@@ -12,6 +12,8 @@ import type {
   PlasmoCSUIHTMLContainer
 } from "~type"
 
+import "@plasmo-static-common/vue"
+
 // @ts-ignore
 import RawMount from "__plasmo_mount_content_script__"
 // @ts-ignore

--- a/cli/plasmo/templates/static/vue3/index.ts
+++ b/cli/plasmo/templates/static/vue3/index.ts
@@ -3,6 +3,13 @@ import { createApp } from "vue"
 
 import * as Component from "__plasmo_import_module__"
 
+__VUE_OPTIONS_API__ = true
+if(process.env.NODE_ENV !== 'production') {
+  __VUE_PROD_DEVTOOLS__ = true
+} else {
+  __VUE_PROD_DEVTOOLS__ = false
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   const app = createApp(Component.default)
   Component.default.prepare?.(app)

--- a/cli/plasmo/templates/static/vue3/index.ts
+++ b/cli/plasmo/templates/static/vue3/index.ts
@@ -1,14 +1,9 @@
-// @ts-nocheck
 import { createApp } from "vue"
 
+// @ts-ignore
 import * as Component from "__plasmo_import_module__"
 
-__VUE_OPTIONS_API__ = true
-if(process.env.NODE_ENV !== 'production') {
-  __VUE_PROD_DEVTOOLS__ = true
-} else {
-  __VUE_PROD_DEVTOOLS__ = false
-}
+import "@plasmo-static-common/vue"
 
 document.addEventListener("DOMContentLoaded", () => {
   const app = createApp(Component.default)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

Vue is ouputting the following error in console:

```
__VUE_OPTIONS_API__, __VUE_PROD_DEVTOOLS__ are not explicitly defined. You are running the esm-bundler build of Vue, which expects these compile-time feature flags to be globally injected via the bundler config in order to get better tree-shaking in the production bundle.

For more details, see https://link.vuejs.org/feature-flags.
```

This is fixable by assigning a boolean value to each of these global variables but it needs to be done before `createApp()` is called. There is no configuration option in Parcel to handle this so I assigned values to these variables in the Vue3 static template file (cli/plasmo/templates/static/vue3/index.ts).

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: dino_morrison

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
