### PR TITLE
Add serve host and hmr host options to the development script

### DIFF
--- a/cli/plasmo/src/commands/dev.ts
+++ b/cli/plasmo/src/commands/dev.ts
@@ -19,7 +19,9 @@ async function dev() {
   process.env.NODE_ENV = "development"
 
   const rawServePort = getFlag("--serve-port") || "1012"
+  const serveHost = getFlag("--serve-host") || "localhost"
   const rawHmrPort = getFlag("--hmr-port") || "1815"
+  const hmrHost = getFlag("--hmr-host") || "localhost"
 
   iLog("Starting the extension development server...")
 
@@ -31,7 +33,7 @@ async function dev() {
   ])
   const buildWatcher = getBuildSocket(hmrPort)
 
-  vLog(`Starting dev server on ${servePort}, HMR on ${hmrPort}...`)
+  vLog(`Starting dev server on ${serveHost}:${servePort}, HMR on ${hmrHost}:${hmrPort}...`)
 
   const bundleConfig = getBundleConfig()
 
@@ -43,11 +45,11 @@ async function dev() {
     logLevel: "verbose",
     shouldBundleIncrementally: true,
     serveOptions: {
-      host: "localhost",
+      host: serveHost,
       port: servePort
     },
     hmrOptions: {
-      host: "localhost",
+      host: hmrHost,
       port: hmrPort
     }
   })


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR exposes the host options for the development server (via --serve-host) and the hot module reload (via --hmr-host).

We would like these options exposed because our local development environment runs from inside a Docker container. We need a way to expose the development server and HMR that's running inside the Docker container to the local machine to make the development environment work properly.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: N/A

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
