### PR TITLE
fix: Explicitly set comment preservation option when building

### DIFF
--- a/core/parcel-optimizer-es/src/index.ts
+++ b/core/parcel-optimizer-es/src/index.ts
@@ -51,7 +51,7 @@ export default new Optimizer({
         target: process.env.__PLASMO_FRAMEWORK_INTERNAL_ES_TARGET,
         minify: {
           format: {
-            comments: shouldMinify ? "some": "all"
+            comments: shouldMinify ? "some" : "all"
           },
           mangle: shouldMinify,
           compress: shouldMinify,

--- a/core/parcel-optimizer-es/src/index.ts
+++ b/core/parcel-optimizer-es/src/index.ts
@@ -50,6 +50,9 @@ export default new Optimizer({
       jsc: {
         target: process.env.__PLASMO_FRAMEWORK_INTERNAL_ES_TARGET,
         minify: {
+          format: {
+            comments: shouldMinify ? "some": "all"
+          },
           mangle: shouldMinify,
           compress: shouldMinify,
           sourceMap: sourceMapType !== "none",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

The current included version of `@swc/core` changed the default behavior of comment preservation when minifying code. This change explicitly sets the choice to maintain consistent results in compiled scripts.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: `filthytone`

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
