### PR TITLE
Switch inject-socket to use getSocketHostname

### DIFF
--- a/core/parcel-runtime/src/utils/0-patch-module.ts
+++ b/core/parcel-runtime/src/utils/0-patch-module.ts
@@ -59,6 +59,14 @@ export function getHostname() {
   return runtimeData.host
 }
 
+export function getSocketHostname() {
+  if (!runtimeData.host || runtimeData.host === "0.0.0.0") {
+    return "localhost";
+  }
+
+  return runtimeData.host
+}
+
 export function getPort() {
   return runtimeData.port || location.port
 }

--- a/core/parcel-runtime/src/utils/inject-socket.ts
+++ b/core/parcel-runtime/src/utils/inject-socket.ts
@@ -2,10 +2,10 @@ import { type BuildSocketEvent } from "@plasmo/framework-shared/build-socket/eve
 import { eLog, iLog, wLog } from "@plasmo/utils/logging"
 
 import type { HmrAsset, HmrMessage } from "../types"
-import { getHostname, getPort, runtimeData } from "./0-patch-module"
+import { getSocketHostname, getPort, runtimeData } from "./0-patch-module"
 
 function getBaseSocketUri(port = getPort()) {
-  const hostname = getHostname()
+  const hostname = getSocketHostname()
   const protocol =
     runtimeData.secure ||
     (location.protocol === "https:" &&


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

In two previous PRs, support for changing the HMR host and serve host were added:
https://github.com/PlasmoHQ/plasmo/pull/745
https://github.com/PlasmoHQ/plasmo/commit/fa6045e352df956a95ae56e683bcc4ddf2c00c47

Unfortunately, the HMR was still not working when binding to 0.0.0.0. After some exploration, one culprit is that the content script UI isn't successfully connecting to the HMR server. The function it was using to get the hostname of the HMR server would return the location's hostname where the content script was opened on. This PR adds a new function that ensures when fetching the hostname for a socket, it returns "localhost" by default instead of the location's hostname.

I've tested this method of getting the hostname for the socket connection is working in content script UIs and the background worker.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.
