### PR TITLE
feat(messaging): More explicit error message when no active tabs

### DIFF
--- a/api/messaging/src/index.ts
+++ b/api/messaging/src/index.ts
@@ -26,7 +26,11 @@ export const sendToBackground: PlasmoMessaging.SendFx<MessageName> = async (
  */
 export const sendToContentScript: PlasmoMessaging.SendFx = async (req) => {
   const tabId =
-    typeof req.tabId === "number" ? req.tabId : (await getActiveTab()).id
+    typeof req.tabId === "number" ? req.tabId : (await getActiveTab())?.id
+
+  if (!tabId) {
+    throw new Error("No active tab found to send message to.")
+  }
 
   return getExtTabs().sendMessage(tabId, req)
 }

--- a/api/messaging/src/utils.ts
+++ b/api/messaging/src/utils.ts
@@ -27,7 +27,7 @@ export const getActiveTab = async () => {
     active: true,
     currentWindow: true
   })
-  return tab
+  return tab as chrome.tabs.Tab | undefined
 }
 
 export const isSameOrigin = (


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This error message when trying to send a message when there are no active tabs (for example when you're on a `chrome://` page) is a bit cryptic at the moment (`Cannot find property id of undefined`). This PR throws a more explicit error instead.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- Discord ID: 380325824286687233
