### PR TITLE
feat: support for messaging from main world content scripts

### DIFF
--- a/api/messaging/src/index.ts
+++ b/api/messaging/src/index.ts
@@ -13,12 +13,13 @@ export type {
 
 /**
  * Should only be called from CS or Ext Pages
+ * Extension Id is required to send a message from a CS in the main world
  * TODO: Add a framework runtime check, using a global variable
  */
 export const sendToBackground: PlasmoMessaging.SendFx<MessageName> = async (
   req
 ) => {
-  return getExtRuntime().sendMessage(req)
+    return getExtRuntime().sendMessage(req.extensionId ?? null, req)
 }
 
 /**

--- a/api/messaging/src/types.ts
+++ b/api/messaging/src/types.ts
@@ -10,6 +10,7 @@ export namespace PlasmoMessaging {
   export type Request<TName = any, TBody = any> = {
     name: TName
 
+    extensionId?: string
     port?: chrome.runtime.Port
     sender?: chrome.runtime.MessageSender
 

--- a/cli/plasmo/src/features/background-service-worker/bgsw-messaging.ts
+++ b/cli/plasmo/src/features/background-service-worker/bgsw-messaging.ts
@@ -28,6 +28,16 @@ globalThis.__plasmoInternalPortMap = new Map()
 
 ${importSection}
 
+chrome.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
+  switch (request.name) {
+    ${switchCaseSection}
+    default:
+      break
+  }
+
+  return true
+})
+
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   switch (request.name) {
     ${switchCaseSection}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR ...

Allows usage of the message API when the content script is in the main world. 

To send messages from content scripts in the main world chrome requires the following: 

- The extension's id to be passed as a string to sendMessage()
- The service worker's listener to use onMessageExternal() instead of onMessage()

<a href="https://developer.chrome.com/docs/extensions/mv3/messaging/#external-webpage" target="_blank">Read details from chrome here</a>

[I also submitted a PR to the docs that explains this change](https://github.com/PlasmoHQ/docs/pull/88)

This is my first proper PR to open source so please be kind ❤️ 

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

