### PR TITLE
Messaging: Fix async listeners

### DIFF
--- a/api/messaging/src/index.ts
+++ b/api/messaging/src/index.ts
@@ -12,18 +12,19 @@ export type {
 } from "./types"
 
 /**
- * Should only be called from CS or Ext Pages
- * Extension Id is required to send a message from a CS in the main world
- * TODO: Add a framework runtime check, using a global variable
+ * Send to Background Service Workers from Content Scripts or Extension pages.
+ * `extensionId` is required to send a message from a Content Script in the main world
  */
+// TODO: Add a framework runtime check, using a global variable
 export const sendToBackground: PlasmoMessaging.SendFx<MessageName> = async (
   req
 ) => {
-    return getExtRuntime().sendMessage(req.extensionId ?? null, req)
+  return getExtRuntime().sendMessage(req.extensionId ?? null, req)
 }
 
 /**
- * Send to CS from Ext pages or BGSW, default to active tab if no tabId is provided in the request
+ * Send to Content Scripts from Extension pages or Background Service Workers.
+ * Default to active tab if no tabId is provided in the request
  */
 export const sendToContentScript: PlasmoMessaging.SendFx = async (req) => {
   const tabId =

--- a/api/messaging/src/message.ts
+++ b/api/messaging/src/message.ts
@@ -4,7 +4,11 @@ import { getExtRuntime } from "./utils"
 export const listen = <RequestBody, ResponseBody>(
   handler: PlasmoMessaging.Handler<string, RequestBody, ResponseBody>
 ) => {
-  const metaListener = async (req, sender, sendResponse) => {
+  const metaListener = async (
+    req: any,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (response?: ResponseBody) => void
+  ) => {
     await handler?.(
       {
         ...req,
@@ -16,9 +20,13 @@ export const listen = <RequestBody, ResponseBody>(
     )
   }
 
-  const listener = (req, sender, sendResponse) => {
+  const listener = (
+    req: any,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (response?: ResponseBody) => void
+  ) => {
     metaListener(req, sender, sendResponse)
-    return // Syncronous return to indicate this is an async listener
+    return true // Synchronous return to indicate this is an async listener
   }
 
   getExtRuntime().onMessage.addListener(listener)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR fixes an issue where async listeners would not work:

CS:
```js
listen(async (req, res) => {
  if (req.name === "getTabURL") {
    await timeout(1000)
    res.send(location.href)
    return
  } else {
    res.send("ERROR")
  }
})
```

BGSW:
```js
await sendToContentScript({ name: "getTabURL" }) // will return undefined
```

See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#sending_an_asynchronous_response_using_sendresponse

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

