### PR TITLE
fix: Popup layout is broken and `display: flex` is unecessary

### DIFF
--- a/packages/init/entries/popup.tsx
+++ b/packages/init/entries/popup.tsx
@@ -6,8 +6,6 @@ function IndexPopup() {
   return (
     <div
       style={{
-        display: "flex",
-        flexDirection: "column",
         padding: 16
       }}>
       <h2>


### PR DESCRIPTION
Besides being unnecessary it causes a layout issue (on Chrome)

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR fixes a layout issue and removes redundant code.

<img width="523" alt="image" src="https://github.com/PlasmoHQ/plasmo/assets/146396/4c60d558-c802-4bf4-9b05-6bce8bacf03b">


### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
