### PR TITLE
Allow React to be detected in NPM Workspaces

### DIFF
--- a/cli/plasmo/src/features/manifest-factory/base.ts
+++ b/cli/plasmo/src/features/manifest-factory/base.ts
@@ -176,7 +176,9 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
 
   get dependencies() {
     ok(this.packageData)
-    return this.packageData.dependencies
+    // to support npm workspaces (mono repos) we need to fallback to
+    // peerDependencies because dependencies will never exist
+    return this.packageData.dependencies ?? this.packageData.peerDependencies
   }
 
   get devDependencies() {

--- a/core/parcel-runtime/src/index.ts
+++ b/core/parcel-runtime/src/index.ts
@@ -27,6 +27,7 @@ export default new Runtime({
       .getConfigFrom<{
         dependencies: Record<string, string>
         devDependencies: Record<string, string>
+        peerDependencies: Record<string, string>
       }>(
         join(process.env.PLASMO_PROJECT_DIR, "lab"), // parcel only look up
         ["package.json"],
@@ -36,7 +37,8 @@ export default new Runtime({
       )
       .then((cfg) => cfg?.contents)
 
-    const hasReact = !!pkg?.dependencies?.react || !!pkg?.devDependencies?.react
+    // npm workspaces mono repo's do not have dependencies or devDependencies (they are defined in a parent directory), fallback to peerDependencies
+    const hasReact = !!pkg?.dependencies?.react || !!pkg?.devDependencies?.react || !!pkg?.peerDependencies?.react
 
     return {
       hasReact


### PR DESCRIPTION
## Details

React is detected by looking for a react devDependency or dependency. NPM Workspaces (mono repos) do not define these in the project package.json. The mono repo will fail if they are defined. The mono repo root has the dependencies listed.

When looking for React in this type of environment, the peerDependencies should be inspected instead.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- Discord ID: deavial

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
