### PR TITLE
feat: move the extRuntime into getExtRuntime

### DIFF
--- a/api/messaging/src/utils.ts
+++ b/api/messaging/src/utils.ts
@@ -1,13 +1,13 @@
 import type { PlasmoMessaging } from "./index"
 
-// TODO: Move this to a broader utils package later on
-const extRuntime = (globalThis.browser?.runtime ||
-  globalThis.chrome?.runtime) as typeof chrome.runtime
-
 const extTabs = (globalThis.browser?.tabs ||
   globalThis.chrome?.tabs) as typeof chrome.tabs
 
 export const getExtRuntime = () => {
+  // TODO: Move this to a broader utils package later on
+  const extRuntime = (globalThis.browser?.runtime ||
+    globalThis.chrome?.runtime) as typeof chrome.runtime
+  
   if (!extRuntime) {
     throw new Error("Extension runtime is not available")
   }


### PR DESCRIPTION
## Details

This PR will move the `extRuntime` into `getExtRuntime`. Because when the user has not installed the extension and the installation is completed, `extRuntime` already exists. However, the current `extRuntime` still an undefined value, and it is impossible to judge whether the installation is completed based on this.

After modification, `extRuntime` can be obtained in real time.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- Discord ID: crazyurus
