### PR TITLE
feat: Support custom .parcelrc config

### DIFF
--- a/cli/plasmo/src/features/extension-devtools/common-path.ts
+++ b/cli/plasmo/src/features/extension-devtools/common-path.ts
@@ -45,6 +45,7 @@ export const getCommonPath = (projectDirectory = cwd()) => {
     packageFilePath: resolve(projectDirectory, "package.json"),
     gitIgnorePath: resolve(projectDirectory, ".gitignore"),
     assetsDirectory: resolve(projectDirectory, "assets"),
+    parcelConfig: resolve(projectDirectory, ".parcelrc"),
 
     dotPlasmoDirectory,
     cacheDirectory,

--- a/cli/plasmo/src/features/helpers/create-parcel-bundler.ts
+++ b/cli/plasmo/src/features/helpers/create-parcel-bundler.ts
@@ -1,9 +1,10 @@
 import { dirname, join, resolve } from "path"
 import ParcelFS from "@parcel/fs"
 import ParcelPM from "@parcel/package-manager"
-import { emptyDir, ensureDir, readJson, writeJson } from "fs-extra"
+import { emptyDir, ensureDir, exists, readJson, writeJson } from "fs-extra"
 
 import { getFlag, hasFlag } from "@plasmo/utils/flags"
+import { wLog } from "@plasmo/utils/logging"
 
 import { Parcel, type ParcelOptions } from "@plasmohq/parcel-core"
 
@@ -65,7 +66,7 @@ export const createParcelBuilder = async (
 
   const baseConfig = require.resolve("@plasmohq/parcel-config")
 
-  const runConfig = join(dirname(baseConfig), "run.json")
+  let runConfig = join(dirname(baseConfig), "run.json")
 
   const configJson = await readJson(baseConfig)
 
@@ -74,6 +75,26 @@ export const createParcelBuilder = async (
   }
 
   await writeJson(runConfig, configJson)
+
+  if (await exists(commonPath.parcelConfig)) {
+    runConfig = commonPath.parcelConfig
+
+    if (isProd) {
+      const customConfig = await readJson(runConfig)
+
+      if (customConfig.extends !== "@plasmohq/parcel-config") {
+        wLog(
+          'The .parcelrc does not extend "@plasmohq/parcel-config", the result may be unexpected'
+        )
+      }
+    }
+
+    if (hasFlag("--bundle-buddy")) {
+      wLog(
+        'The "--bundle-buddy" flag does not work with a custom .parcelrc file'
+      )
+    }
+  }
 
   const engines = {
     browsers:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR introduces support for a custom `.parcelrc` at the root of the project. It will warn the user if the config doesn't extend Plasmo's one.

This serves as an escape hatch for things like https://github.com/PlasmoHQ/plasmo/issues/521 or https://github.com/PlasmoHQ/plasmo/issues/367.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- Discord ID: 380325824286687233
