### PR TITLE
Fix, default to 'inject' css option  in Svelte transformer

### DIFF
--- a/core/parcel-transformer-svelte/src/index.ts
+++ b/core/parcel-transformer-svelte/src/index.ts
@@ -41,7 +41,7 @@ export default new Transformer({
     return {
       compilerOptions: {
         dev: options.mode !== "production",
-        css: "external",
+        css: "injected",
         ...compilerOptions
       } as CompileOptions,
       preprocess: contents.preprocess,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR changes the default value of the `css` option in the Svelte transformer to `inject` instead of `external`

When set to `external` the outputted css file is not included in the bundle and never ends being used by content scripts. Setting it to `inject` embeds the css in the bundled js and it ends up being applied in the content scripts.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: 182694885701189639

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
