### PR TITLE
feat(external_messaging): Adds external messaging resolver

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: "latest"
+          version: v9.0.6
           run_install: false
 
       - name: Get pnpm store directory

--- a/cli/create-plasmo/package.json
+++ b/cli/create-plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-plasmo",
-  "version": "0.85.2",
+  "version": "0.86.0",
   "description": "Create Plasmo Framework Browser Extension",
   "main": "dist/index.js",
   "bin": "bin/index.mjs",

--- a/cli/plasmo/package.json
+++ b/cli/plasmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plasmo",
-  "version": "0.85.2",
+  "version": "0.86.0",
   "description": "The Plasmo Framework CLI",
   "publishConfig": {
     "types": "dist/type.d.ts"

--- a/cli/plasmo/src/features/extension-devtools/package-file.ts
+++ b/cli/plasmo/src/features/extension-devtools/package-file.ts
@@ -55,6 +55,7 @@ const _generatePackage = async ({
 export type PackageJSON = Awaited<ReturnType<typeof _generatePackage>> & {
   homepage?: string
   contributors?: string[]
+  peerDependencies?: Record<string, string>
 }
 
 type GenerateArgs = Parameters<typeof _generatePackage>[0]

--- a/package.json
+++ b/package.json
@@ -61,5 +61,5 @@
     "npm": ">=9.5.0",
     "node": ">=18.0.0"
   },
-  "packageManager": "pnpm@8.15.0"
+  "packageManager": "pnpm@9.0.6"
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

Introduces concept of external messaging handlers. By using the path of `messages/external/`, we can leverage the same messaging features, but they will be registered via `chrome.runtime.onMessageExternal.addListener` instead of `chrome.runtime.onMessage.addListener`.

This fixes an issue currently where all message handlers are being registered as internal AND external handlers, which can be unsafe.

You can either set up a message handler in `background/messages/my-handler.ts` , or `background/messages/external/my-external-handler.ts`. If you want a message handler to work in both contexts, symlink it `ln -s background/messages/my-safe-handler.ts background/messages/external/my-safe-handler.ts`. 

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: filthytone

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
