### PR TITLE
fix(parcel-compressor-utf8): transformChunk with segment size 1024

### DIFF
--- a/core/parcel-compressor-utf8/src/utf8-transform.ts
+++ b/core/parcel-compressor-utf8/src/utf8-transform.ts
@@ -17,8 +17,18 @@ class Utf8Transform extends Transform {
     remainder ? callback(null, this.transformChunk(remainder)) : callback()
   }
 
-  private transformChunk(chunk: string): string {
-    return Array.from(chunk)
+  private transformChunk(chunk: string, segmentSize: number = 1024): string {
+    let result = ""
+    for (let i = 0; i < chunk.length; i += segmentSize) {
+      const endIndex = Math.min(i + segmentSize, chunk.length)
+      const segment = chunk.substring(i, endIndex)
+      result += this.transformSegment(segment)
+    }
+    return result
+  }
+
+  private transformSegment(segment: string): string {
+    return Array.from(segment)
       .map((ch) =>
         ch.charCodeAt(0) <= 0x7f
           ? ch


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR fixes an issue with parcel-compressor-utf8 with big chunk (that cause Array to throws error). It addresses this issue by creating segment of 1024.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: dp__o

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
