### PR TITLE
feat: add post-build hook

### DIFF
--- a/cli/plasmo/src/features/manifest-factory/base.ts
+++ b/cli/plasmo/src/features/manifest-factory/base.ts
@@ -224,6 +224,19 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
         }
       })
     )
+
+    if (!process.env.POST_BUILD_SCRIPT)
+      return
+
+    const postBuildPath = resolve(process.env.POST_BUILD_SCRIPT)
+
+    if (!existsSync(postBuildPath)) {
+      console.error("Post-build file does not exist or is not readable:", postBuildPath)
+      return
+    }
+
+    const postBuild = require(postBuildPath)
+    postBuild()
   }
 
   async updateEnv() {


### PR DESCRIPTION
## Details

Allow to configure a hook to be ran whenever a build is made, so that users can perform post-build tasks. This is especially useful for the `dev` task, as a build is ran each time the filetree changes.

This is an opportunity for users to perform custom tasks that they may need on every builds. To do so, they just have to declare a POST_BUILD_SCRIPT environment variable containing the path to a script, like this:

    POST_BUILD_SCRIPT=./post-build.cjs plasmo dev

The provided script must export a function, which will be executed:

```javascript
module.exports = function() {
  // do stuff after build is done
}
```

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

