### PR TITLE
Set `world` property directly in `manifest.json` to skip extra permission

### DIFF
--- a/cli/plasmo/src/features/background-service-worker/bgsw-main-world-script.ts
+++ b/cli/plasmo/src/features/background-service-worker/bgsw-main-world-script.ts
@@ -10,6 +10,12 @@ import { type PlasmoManifest } from "~features/manifest-factory/base"
 export const createBgswMainWorldInjector = async (
   plasmoManifest: PlasmoManifest
 ) => {
+  const isProd = process.env.NODE_ENV === "production"
+
+  if (isProd) {
+    return false
+  }
+
   try {
     const outputPath = resolve(
       plasmoManifest.commonPath.staticDirectory,

--- a/cli/plasmo/src/features/manifest-factory/base.ts
+++ b/cli/plasmo/src/features/manifest-factory/base.ts
@@ -403,12 +403,16 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
         )
       }
 
+      const isDev = process.env.NODE_ENV === "development"
+
       const contentScript = this.injectEnvToObj({
         matches: ["<all_urls>"],
         js: [
-          metadata?.config?.world === "MAIN"
-            ? scriptPath.split(scriptExt)[0]
-            : scriptPath
+          //!! I am not sure what this actually does??
+          // metadata?.config?.world === "MAIN" && isDev
+          //   ? scriptPath.split(scriptExt)[0]
+          //   : scriptPath
+          scriptPath
         ],
         ...(metadata?.config || {})
       })
@@ -569,10 +573,12 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
       }
     }
 
+    const isDev = process.env.NODE_ENV === "development"
+
     // Populate content_scripts
     base.content_scripts = [
-      ...Array.from(this.contentScriptMap.values()).filter(
-        (s) => s.world !== "MAIN" // TODO: Remove this when Chrome natively supports mainworld for CS
+      ...Array.from(this.contentScriptMap.values()).filter((s) =>
+        isDev ? s.world !== "MAIN" : true
       ),
       ...(overrideContentScripts! || [])
     ]

--- a/cli/plasmo/src/features/manifest-factory/create-manifest.ts
+++ b/cli/plasmo/src/features/manifest-factory/create-manifest.ts
@@ -39,7 +39,7 @@ export async function createManifest(bundleConfig: PlasmoBundleConfig) {
     plasmoManifest.addPagesDirectory(sandboxesDirectory)
   ])
 
-  // BGSW needs to check CS set for main world
+  // Check for scripts to be bundled as the background service worker
   initResults.push(await updateBgswEntry(plasmoManifest))
 
   const hasEntrypoints = initResults.flat()

--- a/core/parcel-transformer-manifest/src/schema.ts
+++ b/core/parcel-transformer-manifest/src/schema.ts
@@ -185,7 +185,11 @@ const commonProps = {
           type: "string",
           enum: ["document_idle", "document_start", "document_end"]
         },
-        all_frames: booleanSchema
+        all_frames: booleanSchema,
+        world: {
+          type: "string",
+          enum: ["MAIN", "ISOLATED"]
+        }
       },
       additionalProperties: false,
       required: ["matches"]


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR disables loading Content Scripts, where `world: 'MAIN'` is set, using background script. The previous approach causes extra permission in to be added, which negatively impacts Chrome Store reviews and provides arguably a more scary warning popup (permission popup on install) to end users than what is necessary.

However, it keeps the existing behaviour for development to take advantage of automatically triggered browser refreshes.

This PR passes on the world property directly to the manifest. It is officially supported by the chrome. https://developer.chrome.com/docs/extensions/reference/api/scripting#type-ExecutionWorld

It is however not supported by Firefox but that doesn't alter the current behaviour (it is not supported at all).
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/ExecutionWorld#browser_compatibility

This is also the answer to my question here https://github.com/PlasmoHQ/plasmo/pull/433#issuecomment-1811057098.

Legacy discussion for the initial implementation: https://github.com/PlasmoHQ/plasmo/issues/422

### Code of Conduct

- [X] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [X] I agree to license this contribution under the MIT LICENSE
- [X] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
