### PR TITLE
fix(docs): document the `--zip` flag in the `plasmo build` CLI

### DIFF
--- a/cli/plasmo/src/features/helpers/flag.ts
+++ b/cli/plasmo/src/features/helpers/flag.ts
@@ -35,6 +35,13 @@ export const getFlagMap = () => {
   }
 }
 
+const DEV_BUILD_COMMON_ARGS = `      --target [string]           set the target (default: chrome-mv3)
+      --tag [string]              set the build tag (default: dev or prod depending on NODE_ENV)
+      --src-path [path]           set the source path relative to project root (default: src)
+      --build-path [path]         set the build path relative to project root (default: build)
+      --entry                     entry point name (default: popup)
+      --env                       relative path to top-level env file`
+
 export const flagHelp = `
     
     init
@@ -42,12 +49,12 @@ export const flagHelp = `
       --entry                     entry files (default: popup)
       --with-<name>               use an example template
 
-    dev/build     
+    dev     
 
-      --target [string]           set the target (default: chrome-mv3)
-      --tag [string]              set the build tag (default: dev or prod depending on NODE_ENV)
-      --src-path [path]           set the source path relative to project root (default: src)
-      --build-path [path]         set the build path relative to project root (default: build)
-      --entry                     entry point name (default: popup)
-      --env                       relative path to top-level env file
+${DEV_BUILD_COMMON_ARGS}
+
+    build
+
+${DEV_BUILD_COMMON_ARGS}
+      --zip                       zip the build output
 `


### PR DESCRIPTION
## Details

The `plasmo build` CLI supports a `--zip` flag which builds your extension and then packages it into a ZIP file.

This is mentioned in the Plasmo docs, but not in the in-CLI help, which I found confusing.

This adds it to the help output, in the process splitting the documentation for the `dev` and `build` commands.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
