### PR TITLE
fix(docs): clarify in the CLI help that argument values must be specified with `=`

### DIFF
--- a/cli/plasmo/src/features/helpers/flag.ts
+++ b/cli/plasmo/src/features/helpers/flag.ts
@@ -39,15 +39,15 @@ export const flagHelp = `
     
     init
 
-      --entry                     entry files (default: popup)
+      --entry=[name]              entry files (default: popup)
       --with-<name>               use an example template
 
     dev/build     
 
-      --target [string]           set the target (default: chrome-mv3)
-      --tag [string]              set the build tag (default: dev or prod depending on NODE_ENV)
-      --src-path [path]           set the source path relative to project root (default: src)
-      --build-path [path]         set the build path relative to project root (default: build)
-      --entry                     entry point name (default: popup)
-      --env                       relative path to top-level env file
+      --target=[string]           set the target (default: chrome-mv3)
+      --tag=[string]              set the build tag (default: dev or prod depending on NODE_ENV)
+      --src-path=[path]           set the source path relative to project root (default: src)
+      --build-path=[path]         set the build path relative to project root (default: build)
+      --entry=[name]              entry point name (default: popup)
+      --env=[path]                relative path to top-level env file
 `


### PR DESCRIPTION
## Details

Unlike many CLIs, the `plasmo` CLI requires argument values to be provided with `=` notation (e.g. `--target=chrome-mv3`).

This requirement comes from the `getFlag` method in the `@plasmo/utils` package.

https://github.com/PlasmoHQ/plasmo-utils/blob/2838ca6214117bfd93b566b4b75586f6a9bd89f7/flags.ts#L8-L16

This expectation isn't clear in the documentation in the CLI, which is quite misleading. This fixes that, updating all of the examples to clearly show setting a value with `=`.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
