### PR TITLE
feat: log the target when running `plasmo build` or `plasmo dev`

### DIFF
--- a/cli/plasmo/src/commands/build.ts
+++ b/cli/plasmo/src/commands/build.ts
@@ -27,6 +27,8 @@ async function build() {
 
   const bundleConfig = getBundleConfig()
 
+  iLog("Building for target:", bundleConfig.target)
+
   const plasmoManifest = await createManifest(bundleConfig)
 
   const bundler = await createParcelBuilder(plasmoManifest, {

--- a/cli/plasmo/src/commands/dev.ts
+++ b/cli/plasmo/src/commands/dev.ts
@@ -39,6 +39,8 @@ async function dev() {
 
   const bundleConfig = getBundleConfig()
 
+  iLog("Building for target:", bundleConfig.target)
+
   const plasmoManifest = await createManifest(bundleConfig)
 
   const projectWatcher = await createProjectWatcher(plasmoManifest)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This logs the `--target` when running `plasmo build` or `plasmo dev`, making it easy to see at a glance what browser target you are building for.

This can help to avoid surprises and confusion if the thing you think is getting built isn't getting built!

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
