### PR TITLE
Add 'overrides' key for browser-specific manifest settings

### DIFF
--- a/cli/plasmo/src/features/manifest-factory/base.ts
+++ b/cli/plasmo/src/features/manifest-factory/base.ts
@@ -596,7 +596,7 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
       return {}
     }
 
-    const output = await this.prepareOverrideManifest()
+    let output = await this.prepareOverrideManifest()
 
     if ((output.web_accessible_resources?.length || 0) > 0) {
       output.web_accessible_resources = await this.resolveWAR(
@@ -623,7 +623,11 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
           delete output.browser_specific_settings
       }
     }
-
+    
+    if (output.overrides && output.overrides[this.browser]) {
+      output = { ...output, ...(output.overrides[this.browser] || {}) }
+      delete output.overrides
+    }
     return this.injectEnvToObj(output)
   }
 

--- a/cli/plasmo/src/features/manifest-factory/base.ts
+++ b/cli/plasmo/src/features/manifest-factory/base.ts
@@ -623,9 +623,9 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
           delete output.browser_specific_settings
       }
     }
-    
+
     if (output.overrides && output.overrides[this.browser]) {
-      output = { ...output, ...(output.overrides[this.browser] || {}) }
+      output = { ...output, ...output.overrides[this.browser] }
       delete output.overrides
     }
     return this.injectEnvToObj(output)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

Add `overrides` key to manifest to allow setting browser-specific manifest key-values, using just a dumb shallow-merge.

I personally needed this feature because Firefox CSP automatically upgrades HTTP connections to HTTPS, but setting anything else broke functionality in Safari.

Related PRs:
* https://github.com/PlasmoHQ/examples/pull/67
* https://github.com/PlasmoHQ/plasmo-constants/pull/2

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: tbrockman

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
