### PR TITLE
Set bundle config as internal environment variables

### DIFF
--- a/cli/plasmo/src/features/env/env-config.ts
+++ b/cli/plasmo/src/features/env/env-config.ts
@@ -89,6 +89,12 @@ function maybeParseJSON(value: string): any {
   return match ? JSON.parse(match[1]) : value
 }
 
+export const setInternalEnv = (env: Record<string, string>) => {
+  for (const [key, value] of Object.entries(env)) {
+    process.env[`${INTERNAL_ENV_PREFIX}${constantCase(key)}`] = value
+  }
+}
+
 export const getEnvFileNames = () => {
   const nodeEnv = process.env.NODE_ENV
   const flagMap = getFlagMap()

--- a/cli/plasmo/src/features/helpers/create-parcel-bundler.ts
+++ b/cli/plasmo/src/features/helpers/create-parcel-bundler.ts
@@ -11,6 +11,7 @@ import { Parcel, type ParcelOptions } from "@plasmohq/parcel-core"
 import type { PlasmoManifest } from "~features/manifest-factory/base"
 
 import { getPackageManager } from "./package-manager"
+import { setInternalEnv } from "~features/env/env-config"
 
 const PackageInstallerMap = {
   npm: ParcelPM.Npm,
@@ -103,6 +104,8 @@ export const createParcelBuilder = async (
         ? ["IE 11"]
         : ["last 1 Chrome version"]
   }
+
+  setInternalEnv(bundleConfig)
 
   const bundler = new Parcel({
     inputFS,


### PR DESCRIPTION
## Details

So that variables like `PLASMO_BROWSER` are accessible in downstream Parcel plugins via `process.env`.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
