### PR TITLE
fix: checkNewVersion Blocks dev and build Commands

### DIFF
--- a/cli/plasmo/src/commands/build.ts
+++ b/cli/plasmo/src/commands/build.ts
@@ -12,7 +12,7 @@ import { zipBundle } from "~features/manifest-factory/zip"
 
 async function build() {
   printHeader()
-  await checkNewVersion()
+  checkNewVersion()
 
   process.env.NODE_ENV = "production"
 

--- a/cli/plasmo/src/commands/dev.ts
+++ b/cli/plasmo/src/commands/dev.ts
@@ -14,7 +14,7 @@ import { createManifest } from "~features/manifest-factory/create-manifest"
 
 async function dev() {
   printHeader()
-  await checkNewVersion()
+  checkNewVersion()
 
   process.env.NODE_ENV = "development"
 

--- a/cli/plasmo/src/commands/package.ts
+++ b/cli/plasmo/src/commands/package.ts
@@ -9,7 +9,7 @@ import { zipBundle } from "~features/manifest-factory/zip"
 
 async function packageCmd() {
   printHeader()
-  await checkNewVersion()
+  checkNewVersion()
 
   process.env.NODE_ENV = "production"
 


### PR DESCRIPTION
#1081

## Details

This PR addresses an issue with the checkNewVersion function. Currently, checkNewVersion is using await, which causes both the dev and build commands to wait until checkNewVersion finishes executing. This results in a delay before these commands can start, affecting the overall developer experience.

### Code of Conduct

- [ x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x ] I agree to license this contribution under the MIT LICENSE
- [x ] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: 

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
