### PR TITLE
bug: Ignore external folder when globbing messages folder

### DIFF
--- a/cli/plasmo/src/features/background-service-worker/bgsw-messaging.ts
+++ b/cli/plasmo/src/features/background-service-worker/bgsw-messaging.ts
@@ -1,7 +1,7 @@
-import { join, resolve } from "path"
 import { camelCase } from "change-case"
 import glob from "fast-glob"
 import { outputFile } from "fs-extra"
+import { join, resolve } from "path"
 
 import { isWriteable } from "@plasmo/utils/fs"
 import { vLog, wLog } from "@plasmo/utils/logging"
@@ -77,7 +77,8 @@ const getHandlerList = async (
 
   const handlerFileList = await glob("**/*.ts", {
     cwd: handlerDir,
-    onlyFiles: true
+    onlyFiles: true,
+    ignore: dirName === "messages" ? ["external"] : []
   })
 
   return handlerFileList.map((filePath) => {


### PR DESCRIPTION
## Details

Fixes a build error that occurs when a custom .babelrc is provided in the project that makes use of `@babel/preset-env`.

#### The error

If you have a .babelrc and an external message such as `src/background/messages/external/Test.ts`, you will receive the following trying to build the extension:

```
Identifier 'messagesExternalTest' has already been declared. (38:20)
```

#### Root cause

In `cli/plasmo/src/features/background-service-worker/bgsw-messaging.ts`'s `getHandlerList` function, it performs a glob of all typescript files that are within the designated messages folder. Due to `messages/external` (public external messaging) being contained within `messages` (extension internal messaging), this causes any external messaging to have a duplicate import created during build when `getHandlerList` is invoked with `dirName: "messaging"` colliding with  the invokation of `dirName: "messaging/external"`. Parcel happily removes the duplicate import, but unfortunately if you configure `@babel/preset-env` for your extension (e.g. targeting older browsers), this triggers a hard error from babel.

#### The fix
Since `messages/external` folder should be ignored when `getHandlerList` is given `dirName: "messaging"`, simply add a glob ignore in that case.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: xiata (469966695084195860)

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
