### PR TITLE
feat: add build loading awareness in the terminal(#1117)

### DIFF
--- a/cli/plasmo/src/features/helpers/loading-animation.ts
+++ b/cli/plasmo/src/features/helpers/loading-animation.ts
@@ -1,0 +1,26 @@
+let loadingInterval: NodeJS.Timeout | null = null
+let isLoading = false
+
+export const startLoading = () => {
+  if (isLoading) return
+  isLoading = true
+  let dots = 0
+  const baseString = "🔄 Building"
+  process.stdout.write(baseString)
+  loadingInterval = setInterval(() => {
+    dots = (dots + 1) % 4
+    let dotString = dots === 0 ? "   " : ".".repeat(dots)
+    process.stdout.write(`\r${baseString}${dotString}`)
+  }, 400)
+}
+
+export const stopLoading = () => {
+  if (!isLoading) return
+  isLoading = false
+  if (loadingInterval) {
+    clearInterval(loadingInterval)
+    loadingInterval = null
+  }
+  // Clear the loading text
+  process.stdout.write("\r" + " ".repeat(20) + "\r")
+}

--- a/cli/plasmo/src/features/helpers/loading-animation.ts
+++ b/cli/plasmo/src/features/helpers/loading-animation.ts
@@ -1,25 +1,31 @@
-let loadingInterval: NodeJS.Timeout | null = null
-let isLoading = false
+const LOADING_TEXT = "🔄 Building"
+const state = {
+  loadingInterval: null as NodeJS.Timeout | null,
+  isLoading: false,
+  dotCount: 0
+}
 
 export const startLoading = () => {
-  if (isLoading) return
-  isLoading = true
-  let dots = 0
-  const baseString = "🔄 Building"
-  process.stdout.write(baseString)
-  loadingInterval = setInterval(() => {
-    dots = (dots + 1) % 4
-    let dotString = dots === 0 ? "   " : ".".repeat(dots)
-    process.stdout.write(`\r${baseString}${dotString}`)
+  if (state.isLoading) {
+    return
+  }
+  state.isLoading = true
+  process.stdout.write(LOADING_TEXT)
+  state.loadingInterval = setInterval(() => {
+    state.dotCount = (state.dotCount + 1) % 4
+    let dotString = state.dotCount === 0 ? "   " : ".".repeat(state.dotCount)
+    process.stdout.write(`\r${LOADING_TEXT}${dotString}`)
   }, 400)
 }
 
 export const stopLoading = () => {
-  if (!isLoading) return
-  isLoading = false
-  if (loadingInterval) {
-    clearInterval(loadingInterval)
-    loadingInterval = null
+  if (!state.isLoading) {
+    return
+  }
+  state.isLoading = false
+  if (state.loadingInterval) {
+    clearInterval(state.loadingInterval)
+    state.loadingInterval = null
   }
   // Clear the loading text
   process.stdout.write("\r" + " ".repeat(20) + "\r")

--- a/core/parcel-core/src/index.ts
+++ b/core/parcel-core/src/index.ts
@@ -161,7 +161,7 @@ export class Parcel {
       throw new BuildError(result.diagnostics)
     }
 
-    return result
+    return result as BuildSuccessEvent
   }
 
   async _end(): Promise<void> {
@@ -259,6 +259,11 @@ export class Parcel {
       if (options.shouldProfile) {
         await this.startProfiling()
       }
+
+      this.#watchEvents.emit({
+        buildEvent: { type: "buildStart" }
+      })
+
       this.#reporterRunner.report({
         type: "buildStart"
       })


### PR DESCRIPTION
## Details

This PR enhances the build process feedback by implementing a loading animation in the terminal. It addresses the issue of unclear build status during development, especially for longer builds or multiple hot reloads.

Specifically, this PR:
- Adds a loading animation at the start of each build/hot reload process
- Removes the animation when the build completes (success or failure)
- Improves visibility of the current build status

This change aims to solve the problem described in issue #1117, where it was difficult to determine if a build was in progress or completed, especially after multiple hot reloads.

I'm open to any feedback or suggestions for improvement. If you have any questions or if there's anything you'd like me to modify, please leave a comment.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: actopas
