### PR TITLE
fix: semicolon bugfix for TrustedTypePolicy Creation in Loading Indicator

### DIFF
--- a/core/parcel-runtime/src/utils/loading-indicator.ts
+++ b/core/parcel-runtime/src/utils/loading-indicator.ts
@@ -21,7 +21,7 @@ function createTrustedPolicy() {
   )?.content?.split(" ")
 
   const trustedKey = trustedTypeLists
-    ? trustedTypeLists[trustedTypeLists?.length - 1]
+    ? trustedTypeLists[trustedTypeLists?.length - 1].replace(/;/g, "")
     : undefined
 
   // Function to update the CSP to allow the new trusted type policy or use existing policy


### PR DESCRIPTION
## Details

Last June, [this PR](https://github.com/PlasmoHQ/plasmo/pull/1000) was created to fix a bug in the Loading Indicator which caused it to break on some websites (e.g. LinkedIn) because the newly-created trusted-type was not valid per the site's CSP for `trusted-types`. For example, if you run the following on LinkedIn:

```
document.querySelector('meta[name="trusted-types"]')
```

You get this `meta` tag:

```
<meta name="trusted-types" content="require-trusted-types-for 'script'; trusted-types default jSecure 'allow-duplicates' dompurify;" data-sanitizer="RegExp" data-pattern="<" data-replacement="&amp;lt;" data-report-to="/security/csp?a=web">
```

The `trusted-types` of which notably do not include the policy which was previously being created by default in `loading-indicator.ts` - `"trusted-html__plasmo-loading__"`. So that PR from last year aimed to fix this by grabbing the last element in the list of `trusted-types` from the site's `meta` tag if there is one, and using that to create the `TrustedPolicy` needed for the loading indicator.

However, there is a small bug in this logic: the code currently calls `.split(" ")` on the `content` of the `meta` tag from the site and takes the last element in the list. Maybe this is a recent update to this tag on LinkedIn, but at least in the case of that site, the last element incorrectly includes a semicolon at the end (see `meta` tag above).

So ultimately we try to create a `TrustedPolicy` with `window.trustedTypes.createPolicy("dompurify;")` which _is not valid and throws an error_. Replacing `;` characters in the name with empty strings should fix this bug.

Example:

<img width="649" alt="Screenshot 2025-02-08 at 6 29 25 PM" src="https://github.com/user-attachments/assets/abdad4d7-ad0b-4da1-a9b2-8b1a6a4f61fb" />

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: solastley `261576894757994496`

If your PR is accepted, we will award you with the `Contributor` role on Discord server. 🎉 

To join the server, visit: https://www.plasmo.com/s/d
