### PR TITLE
chore: fail CI if 'pnpm run build:examples' fails

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -50,6 +50,14 @@ jobs:
       - name: "Go to each example and try to build it"
         run: |
           pnpm run build:examples
+
+          # Check the exit code of the previous command. If it is not 0, the build has failed.
+          # Output an error message and terminate the workflow with a failure status.
+          if [ $? -ne 0 ]; then
+            echo "Build failed" >&2
+            exit 1
+          fi
+
           # pushd examples
           # for d in *
           # do

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -47,26 +47,9 @@ jobs:
           pnpm run build:cli
           pnpm i
 
-      - name: "Go to each example and try to build it"
-        run: |
-          pnpm run build:examples
+      - name: "Build all examples"
+        run: pnpm run build:examples
 
-          # Check the exit code of the previous command. If it is not 0, the build has failed.
-          # Output an error message and terminate the workflow with a failure status.
-          if [ $? -ne 0 ]; then
-            echo "Build failed" >&2
-            exit 1
-          fi
-
-          # pushd examples
-          # for d in *
-          # do
-          #   test -d "$d" || continue
-          #   pushd "$d"
-          #   rm -rf .plasmo
-          #   rm -rf build
-          #   timeout 5 pnpm dev || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi
-          #   popd
-          # done
-          # popd
-          pnpm run test:examples
+      - name: "Test all examples"
+        run: pnpm run test:examples
+          

--- a/core/parcel-core/src/index.ts
+++ b/core/parcel-core/src/index.ts
@@ -157,6 +157,8 @@ export class Parcel {
     let result = await this._build({ startTime })
     await this._end()
 
+    console.log("Got result type", result.type)
+
     if (result.type === "buildFailure") {
       throw new BuildError(result.diagnostics)
     }

--- a/core/parcel-core/src/index.ts
+++ b/core/parcel-core/src/index.ts
@@ -157,8 +157,6 @@ export class Parcel {
     let result = await this._build({ startTime })
     await this._end()
 
-    console.log("Got result type", result.type)
-
     if (result.type === "buildFailure") {
       throw new BuildError(result.diagnostics)
     }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR makes sure the CI fails if a package fails to build. Currently, we are seeing examples fail to build, but the CI passes anyway 👎 

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
