### PR TITLE
chore: replace ssh urls with https urls in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,25 +1,25 @@
 [submodule "packages/rps"]
 	path = packages/rps
-	url = git@github.com:PlasmoHQ/rps.git
+	url = https://github.com/PlasmoHQ/rps.git
 	branch = main
 [submodule "packages/puro"]
 	path = packages/puro
-	url = git@github.com:PlasmoHQ/puro.git
+	url = https://github.com/PlasmoHQ/puro.git
 	branch = main
 [submodule "packages/gcp-refresh-token"]
 	path = packages/gcp-refresh-token
-	url = git@github.com:PlasmoHQ/gcp-refresh-token.git
+	url = https://github.com/PlasmoHQ/gcp-refresh-token.git
 	branch = main
 [submodule "packages/use-hashed-state"]
 	path = packages/use-hashed-state
-	url = git@github.com:PlasmoHQ/use-hashed-state.git
+	url = https://github.com/PlasmoHQ/use-hashed-state.git
 	branch = main
 [submodule "examples"]
 	path = examples
-	url = git@github.com:PlasmoHQ/examples.git
+	url = https://github.com/PlasmoHQ/examples.git
 [submodule "packages/permission-ui"]
 	path = packages/permission-ui
-	url = git@github.com:PlasmoHQ/permission-ui.git
+	url = https://github.com/PlasmoHQ/permission-ui.git
 [submodule "packages/utils"]
 	path = packages/utils
 	url = https://github.com/PlasmoHQ/plasmo-utils.git
@@ -31,5 +31,5 @@
 	url = https://github.com/PlasmoHQ/plasmo-config.git
 [submodule "api/storage"]
 	path = api/storage
-	url = git@github.com:PlasmoHQ/storage.git
+	url = https://github.com/PlasmoHQ/storage.git
 	branch = main


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR replaces all .gitmodule entries with HTTPS urls instead of SSH urls. This is because there is an [issue with Renovate](https://github.com/renovatebot/renovate/discussions/34113) when cloning submodules using ssh, even if they're public.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
