### PR TITLE
fix: use error.code instead of error.errno for ENOENT handling

### DIFF
--- a/cli/plasmo/src/features/project-creator/git-init.ts
+++ b/cli/plasmo/src/features/project-creator/git-init.ts
@@ -15,7 +15,7 @@ const gitInitAddCommit = async (root: string) => {
     vLog(`${root} is a git repository, bailing ${chalk.bold("git init")}`)
     return false
   } catch (e: any) {
-    if (e.errno === "ENOENT") {
+    if (e.code === "ENOENT") {
       throw new Error("Unable to initialize git repo. `git` not in PATH.")
     }
   }

--- a/cli/plasmo/src/features/project-creator/index.ts
+++ b/cli/plasmo/src/features/project-creator/index.ts
@@ -135,7 +135,7 @@ export class ProjectCreator {
         { cwd: tempDirectory, ignoreStdio: true }
       )
     } catch (error: any) {
-      if (error.errno === "ENOENT") {
+      if (error.code === "ENOENT") {
         throw new Error("Unable to clone example repo. `git` is not in PATH.")
       }
     }


### PR DESCRIPTION

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

Checking `error.errno` can vary across OSes and Node.js versions ((it might be numeric on some systems and string on others). Using `error.code === "ENOENT"` is more consistent and ensures we correctly handle "command not found" errors in a cross-platform way.

Also potentially relates to [issue](https://github.com/PlasmoHQ/plasmo/issues/1160)

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: alexb25

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
