### PR TITLE
Fix: built-in node resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+**/.plasmo
+
 # dependencies
 node_modules
 .pnp

--- a/core/parcel-resolver-post/src/index.ts
+++ b/core/parcel-resolver-post/src/index.ts
@@ -6,6 +6,16 @@ import { handleTsPath } from "./handle-ts-path"
 
 export default new Resolver({
   async resolve(props) {
+    const { specifier } = props;
+
+    if (specifier.startsWith("node:")) {
+      // Tells Parcel not to try bundling it at all
+      return {
+        isExcluded: true
+      }
+    }
+
+    // Otherwise, do your custom logic
     return (
       (await handleHacks(props)) ||
       (await handleTsPath(props)) ||


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR alters ``@plasmohq/parcel-resolver-post`` to skip built-in node type resolution

### Code of Conduct

- [ ] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I agree to license this contribution under the MIT LICENSE
- [ ] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
