### PR TITLE
Fix broken links in readme

### DIFF
--- a/cli/plasmo/README.md
+++ b/cli/plasmo/README.md
@@ -118,7 +118,7 @@ To see a list of supported browser targets, [please refer to our documentation h
 
 The Plasmo community can be found on [Discord](https://www.plasmo.com/s/d). This is the appropriate channel to get help with using the Plasmo Framework.
 
-Our [Code of Conduct](./.github/CODE_OF_CONDUCT.md) applies to all Plasmo community channels.
+Our [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md) applies to all Plasmo community channels.
 
 ## Contributing
 

--- a/cli/plasmo/i18n/README.de-DE.md
+++ b/cli/plasmo/i18n/README.de-DE.md
@@ -101,7 +101,7 @@ Außerdem kannst du auch vermeiden, dass alle Dateien im Hauptverzeichnis liegen
 
 Die Plasmo-Community ist auf [Discord](https://www.plasmo.com/s/d) zu finden. Das ist der richtige Kanal, um Hilfe bei der Verwendung des Plasmo-Frameworks zu erhalten.
 
-Unser [Verhaltenskodex](./.github/CODE_OF_CONDUCT.md) gilt für alle Plasmo Community-Kanäle.
+Unser [Verhaltenskodex](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md) gilt für alle Plasmo Community-Kanäle.
 
 ## Am Projekt beteiligen
 

--- a/cli/plasmo/i18n/README.fr-FR.md
+++ b/cli/plasmo/i18n/README.fr-FR.md
@@ -104,7 +104,7 @@ Enfin, vous pouvez aussi éviter de placer le code source dans votre répertoire
 
 La communauté Plasmo se trouve sur [Discord](https://www.plasmo.com/s/d). C'est le réseau approprié pour obtenir de l'aide sur l'utilisation du cadre Plasmo.
 
-Notre [code de conduite](./.github/CODE_OF_CONDUCT.md) s'applique à tous les canaux de la communauté Plasmo.
+Notre [code de conduite](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md) s'applique à tous les canaux de la communauté Plasmo.
 
 ## Contribution
 

--- a/cli/plasmo/i18n/README.id-ID.md
+++ b/cli/plasmo/i18n/README.id-ID.md
@@ -116,7 +116,7 @@ Untuk melihat daftar target browser yang didukung, [lihat dokumentasi kami di si
 
 Komunitas Plasmo dapat ditemukan di [Discord](https://www.plasmo.com/s/d). Ini adalah saluran yang tepat untuk mendapatkan bantuan dalam menggunakan Plasmo Framework.
 
-[Pedoman Perilaku](./.github/CODE_OF_CONDUCT.md) kami berlaku untuk semua saluran komunitas Plasmo.
+[Pedoman Perilaku](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md) kami berlaku untuk semua saluran komunitas Plasmo.
 
 ## Berkontribusi
 

--- a/cli/plasmo/i18n/README.ja-JP.md
+++ b/cli/plasmo/i18n/README.ja-JP.md
@@ -120,7 +120,7 @@ ext-dir
 
 [Discord](https://www.plasmo.com/s/d)にPlasmoのコミュニティがあります。Plasmo Framework に関するヘルプはこちらでお願いします。
 
-[Code of Conduct](./.github/CODE_OF_CONDUCT.md)は、全てのPlasmoコミュニティに適用されます。
+[Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)は、全てのPlasmoコミュニティに適用されます。
 
 ## コントリビュート
 

--- a/cli/plasmo/i18n/README.ko-KR.md
+++ b/cli/plasmo/i18n/README.ko-KR.md
@@ -120,7 +120,7 @@ ext-dir
 
 Plasmo 커뮤니티는 [Discord](https://www.plasmo.com/s/d)에서 찾을 수 있습니다. Plasmo 프레임워크 사용에 관한 도움을 받기에 적절한 채널입니다.
 
-[행동 강령(Code of Conduct)](./.github/CODE_OF_CONDUCT.md)은 모든 Plasmo 커뮤니티 채널에 적용됩니다.
+[행동 강령(Code of Conduct)](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)은 모든 Plasmo 커뮤니티 채널에 적용됩니다.
 
 ## 기여
 

--- a/cli/plasmo/i18n/README.ru-RU.md
+++ b/cli/plasmo/i18n/README.ru-RU.md
@@ -116,6 +116,8 @@ pnpm dev
 
 Сообщество Plasmo можно найти в [Discord](https://www.plasmo.com/s/d). Это подходящий канал для получения помощи в использовании Plasmo Framework.
 
+Наш [Кодекс поведения](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md) применяется ко всем каналам сообщества Plasmo.
+
 ## Внести свой вклад
 
 Пожалуйста, ознакомьтесь с [рекомендациями по контрибьютингу](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CONTRIBUTING.md) чтобы узнать больше.

--- a/cli/plasmo/i18n/README.tr-TR.md
+++ b/cli/plasmo/i18n/README.tr-TR.md
@@ -116,7 +116,7 @@ Desteklenen tarayıcı hedeflerinin bir listesini görmek için [lütfen buradak
 
 Plasmo topluluğu [Discord](https://www.plasmo.com/s/d)'da. Bu Plasmo Framework'ü kullanma konusunda yardım almak için uygun bir kanaldır.
 
-[Davranış Kurallarımız](./.github/CODE_OF_CONDUCT.md) tüm Plasmo topluluk kanalları için geçerlidir.
+[Davranış Kurallarımız](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md) tüm Plasmo topluluk kanalları için geçerlidir.
 
 ## Katkıda bulunma
 

--- a/cli/plasmo/i18n/README.vi-VN.md
+++ b/cli/plasmo/i18n/README.vi-VN.md
@@ -104,7 +104,7 @@ Cuối cùng, bạn cũng có thể tránh đặt mã nguồn vào thư mục g�
 
 Cộng đồng Plasmo có thể được tìm thấy trên [Discord](https://www.plasmo.com/s/d). Đây là kênh thích hợp để nhận trợ giúp về việc sử dụng Plasmo Framework.
 
-[Quy tắc ứng xử](./.github/CODE_OF_CONDUCT.md) của chúng tôi áp dụng cho tất cả các kênh cộng đồng của Plasmo.
+[Quy tắc ứng xử](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md) của chúng tôi áp dụng cho tất cả các kênh cộng đồng của Plasmo.
 
 ## Đóng góp
 

--- a/cli/plasmo/i18n/README.zh-CN.md
+++ b/cli/plasmo/i18n/README.zh-CN.md
@@ -118,7 +118,7 @@ ext-dir
 
 可以在 [Discord](https://www.plasmo.com/s/d) 找到 Plasmo 社区。这是获得 Plasmo 框架使用帮助的恰当渠道。
 
-我们的 [行为守则](./.github/CODE_OF_CONDUCT.md) 适用于所有 Plasmo 社区频道。
+我们的 [行为守则](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md) 适用于所有 Plasmo 社区频道。
 
 ## 贡献
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

The link to the Code of Conduct was set as `./.github/CODE_OF_CONDUCT.md`, which incorrectly pointed to locations such as `https://github.com/PlasmoHQ/plasmo/blob/main/.github/.github/CODE_OF_CONDUCT.md` and `https://github.com/PlasmoHQ/plasmo/blob/main/cli/plasmo/.github/CODE_OF_CONDUCT.md`. In the i18n version, it pointed to `https://github.com/PlasmoHQ/plasmo/blob/main/cli/plasmo/i18n/.github/CODE_OF_CONDUCT.md`, all of which were incorrect. I corrected the link to use an absolute path, similar to the contributing guidelines. 
Additionally, in the Russian version, there was no mention of the Code of Conduct, so I added the relevant content.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
