### PR TITLE
Fix the bpp link to the correct one

### DIFF
--- a/cli/plasmo/src/features/extension-devtools/git-ignore.ts
+++ b/cli/plasmo/src/features/extension-devtools/git-ignore.ts
@@ -35,7 +35,7 @@ dist/
 # plasmo - https://www.plasmo.com
 .plasmo
 
-# bpp - http://bpp.browser.market/
+# bpp - https://github.com/marketplace/actions/browser-platform-publisher
 keys.json
 
 # typescript

--- a/packages/init/templates/README.md
+++ b/packages/init/templates/README.md
@@ -30,4 +30,4 @@ This should create a production bundle for your extension, ready to be zipped an
 
 ## Submit to the webstores
 
-The easiest way to deploy your Plasmo extension is to use the built-in [bpp](https://bpp.browser.market) GitHub action. Prior to using this action however, make sure to build your extension and upload the first version to the store to establish the basic credentials. Then, simply follow [this setup instruction](https://docs.plasmo.com/framework/workflows/submit) and you should be on your way for automated submission!
+The easiest way to deploy your Plasmo extension is to use the built-in [bpp](https://github.com/marketplace/actions/browser-platform-publisher) GitHub action. Prior to using this action however, make sure to build your extension and upload the first version to the store to establish the basic credentials. Then, simply follow [this setup instruction](https://docs.plasmo.com/framework/workflows/submit) and you should be on your way for automated submission!


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

- This PR fixes a broken link (`https://bpp.browser.market`) to the correct one (`https://github.com/marketplace/actions/browser-platform-publisher`).

- close #1219 

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
