### PR TITLE
fix: trigger unmount when the anchor no longer exists

### DIFF
--- a/cli/plasmo/templates/static/common/csui.ts
+++ b/cli/plasmo/templates/static/common/csui.ts
@@ -161,18 +161,18 @@ export function createAnchorObserver<T>(Mount: PlasmoCSUI<T>) {
 
     // Go through mounted sets and check if they are still mounted
     for (const el of mountState.hostSet) {
-      if (isMounted(el)) {
-        const anchor = mountState.hostMap.get(el)
-        if (!!anchor) {
-          if (anchor.type === "inline") {
-            mountedInlineAnchorSet.add(anchor.element)
-          } else if (anchor.type === "overlay") {
-            overlayHost = el
-          }
+      const anchor = mountState.hostMap.get(el)
+      const anchorExists = document.contains(anchor?.element)
+      if (isMounted(el) && anchorExists) {
+        if (anchor.type === "inline") {
+          mountedInlineAnchorSet.add(anchor.element)
+        } else if (anchor.type === "overlay") {
+          overlayHost = el
         }
       } else {
-        const anchor = mountState.hostMap.get(el)
         anchor.root?.unmount()
+        // Clean up the plasmo-csui element
+        el.remove()
         mountState.hostSet.delete(el)
       }
     }


### PR DESCRIPTION
## Details

This PR fixes unmounting of components when the anchor no longer exists.

Since the anchor wasn't checked, components would stack up on top of each other as the anchor disappears and reappears in the DOM from user interactions.

Also added `el.remove()` to remove the empty `plasmo-csui` elements and clean up the DOM.

Fixes https://github.com/PlasmoHQ/plasmo/issues/551

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- Discord ID: cheesestringer
