### PR TITLE
fix: --source-maps ignored when using --zip

### DIFF
--- a/cli/plasmo/src/commands/build.ts
+++ b/cli/plasmo/src/commands/build.ts
@@ -47,7 +47,7 @@ async function build() {
   await plasmoManifest.postBuild()
 
   if (hasFlag("--zip")) {
-    await zipBundle(plasmoManifest.commonPath)
+    await zipBundle(plasmoManifest.commonPath, hasFlag("--source-maps"))
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To ensure your PR is handled as smoothly as possible, please follow the checklist sections below.
-->

## Details

The build command was ignoring the `--source-maps` flag when combined with the `--zip` option. As a result, builds packaged as zip archives did not include source maps, even if explicitly requested. Source map deletion was introduced by default with [#699](https://github.com/PlasmoHQ/plasmo/pull/669).

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: 687209300887601171

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
