### PR TITLE
fix: handle undefined overrideManifest

### DIFF
--- a/cli/plasmo/src/features/manifest-factory/base.ts
+++ b/cli/plasmo/src/features/manifest-factory/base.ts
@@ -535,7 +535,7 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
       content_scripts: overrideContentScripts,
       background: overrideBackground,
       ...overide
-    } = this.overideManifest as T
+    } = (this.overideManifest || {}) as T
 
     if (base.options_ui?.page) {
       base.options_ui = {


### PR DESCRIPTION
## Details

This PR fixes the `Cannot destructure property 'options_ui' of 'this.overideManifest' as it is undefined` error when creating a Chromium build where the manifest override only contains configuration for `browser_specific_settings`.

Fixes https://github.com/PlasmoHQ/plasmo/issues/1320

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- Discord ID: cheesestringer
