### PR TITLE
fix: add directory traversing for nested content scripts

### DIFF
--- a/cli/plasmo/src/features/manifest-factory/base.ts
+++ b/cli/plasmo/src/features/manifest-factory/base.ts
@@ -77,6 +77,14 @@ export const iconMap = {
 
 export const autoPermissionList: ManifestPermission[] = ["storage"]
 
+const directoryIgnoreSet = new Set([
+  "node_modules",
+  "build",
+  ".plasmo",
+  "coverage",
+  ".git"
+])
+
 const hasher = createHasher({ trim: true, sort: true })
 
 export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
@@ -432,18 +440,40 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
       return false
     }
 
-    return readdir(path, { withFileTypes: true })
-      .then((files) =>
-        Promise.all(
-          files
-            .filter((f) =>
-              f.isFile() && filterFile ? filterFile(f.name) : true
-            )
-            .map((f) => resolve(path, f.name))
-            .map((filePath) => toggleDynamicPath(filePath, true))
-        )
+    const walk = async (currentPath: string): Promise<boolean> => {
+      const files = await readdir(currentPath, { withFileTypes: true })
+
+      const results = await Promise.all(
+        files.map(async (file) => {
+          const filePath = resolve(currentPath, file.name)
+
+          if (file.isSymbolicLink()) {
+            return false
+          }
+
+          if (file.isDirectory()) {
+            if (directoryIgnoreSet.has(file.name)) {
+              return false
+            }
+            return walk(filePath)
+          }
+
+          if (!file.isFile()) {
+            return false
+          }
+
+          if (filterFile && !filterFile(file.name)) {
+            return false
+          }
+
+          return toggleDynamicPath(filePath, true)
+        })
       )
-      .then((results) => results.includes(true))
+
+      return results.includes(true)
+    }
+
+    return walk(path)
   }
 
   addContentScriptsIndexFiles = async () => {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

This PR fixes an issue where when we create deep nested contents scripts, they are not included in the dev/prod builds.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: 770692248773197835

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
