### PR TITLE
fix: handle object format for author field in package.json

### DIFF
--- a/cli/plasmo/src/features/extension-devtools/package-file.ts
+++ b/cli/plasmo/src/features/extension-devtools/package-file.ts
@@ -52,7 +52,19 @@ const _generatePackage = async ({
   return baseData
 }
 
-export type PackageJSON = Awaited<ReturnType<typeof _generatePackage>> & {
+/**
+ * npm author field can be either a string or an object.
+ * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#people-fields-author-contributors
+ */
+export type PackageAuthor =
+  | string
+  | { name?: string; email?: string; url?: string }
+
+export type PackageJSON = Omit<
+  Awaited<ReturnType<typeof _generatePackage>>,
+  "author"
+> & {
+  author?: PackageAuthor
   homepage?: string
   contributors?: string[]
   peerDependencies?: Record<string, string>

--- a/cli/plasmo/src/features/manifest-factory/base.ts
+++ b/cli/plasmo/src/features/manifest-factory/base.ts
@@ -77,6 +77,40 @@ export const iconMap = {
 
 export const autoPermissionList: ManifestPermission[] = ["storage"]
 
+/**
+ * Converts npm package.json author field to string format.
+ * npm allows author to be either a string or an object with name/email/url fields.
+ * Chrome extension manifest requires author to be a string.
+ *
+ * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#people-fields-author-contributors
+ */
+const normalizeAuthor = (
+  author: string | { name?: string; email?: string; url?: string } | undefined
+): string | undefined => {
+  if (!author) {
+    return undefined
+  }
+
+  if (typeof author === "string") {
+    return author
+  }
+
+  // Convert object format to string: "Name <email> (url)"
+  const { name, email, url } = author
+  if (!name) {
+    return undefined
+  }
+
+  let result = name
+  if (email) {
+    result += ` <${email}>`
+  }
+  if (url) {
+    result += ` (${url})`
+  }
+  return result
+}
+
 const hasher = createHasher({ trim: true, sort: true })
 
 export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
@@ -255,7 +289,7 @@ export abstract class PlasmoManifest<T extends ExtensionManifest = any> {
     }
 
     this.data.version = this.packageData.version
-    this.data.author = this.packageData.author
+    this.data.author = normalizeAuthor(this.packageData.author)
 
     this.data.name = this.prefixDev(this.packageData.displayName)
 


### PR DESCRIPTION
## Summary

Fixes #1334

Chrome extension manifest requires the `author` field to be a string, but npm's `package.json` allows `author` to be either:
- A string: `"John Doe"`
- An object: `{ "name": "John Doe", "email": "john@example.com", "url": "https://example.com" }`

When the `author` field is an object, Plasmo was passing it directly to the manifest, causing the validation error:
```
Invalid Web Extension manifest
Expected type string
```

## Changes

1. **Added `normalizeAuthor` helper function** in `base.ts`:
   - Returns `undefined` if no author is provided
   - Returns the string as-is if author is already a string
   - Converts object format to the standard npm string format: `"Name <email> (url)"`

2. **Updated `PackageJSON` type** in `package-file.ts`:
   - Added `PackageAuthor` type that accepts both string and object formats
   - Updated `PackageJSON` to use the new type for the `author` field

## Example

**package.json with object author:**
```json
{
  "author": {
    "name": "Gil B. Chan",
    "email": "bnbcmindnpass@gmail.com",
    "url": "https://github.com/jjangga0214"
  }
}
```

**Generated manifest author:**
```json
{
  "author": "Gil B. Chan <bnbcmindnpass@gmail.com> (https://github.com/jjangga0214)"
}
```

## References
- npm docs on people fields: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#people-fields-author-contributors